### PR TITLE
Compact initialization of mpu6050 driver.

### DIFF
--- a/mpu6050/Makefile
+++ b/mpu6050/Makefile
@@ -2,12 +2,8 @@
 # mpu6050 accelerometer & gyroscope
 #
 ifneq ($(KERNELRELEASE),)
-
 obj-m := mpu6050.o
-
 else
-
-
 ifeq ($(KERNELDIR),)
 ifeq ($(BBB_KERNEL),)
 	$(error Path to kernel tree - KERNELDIR or BBB_KERNEL variable is not defined!)
@@ -16,14 +12,16 @@ endif
 
 KERNELDIR ?= $(BBB_KERNEL)
 
-export ARCH = arm
+export ARCH ?= arm
 export CROSS_COMPILE ?= arm-linux-gnueabihf-
 
+.PHONY: all clean dtb modules clean_objects
 
-.PHONY: all clean dtb
+all: modules dtb
 
-all:
+modules:
 	$(MAKE) -C $(KERNELDIR) M=$(CURDIR) modules
+	make clean_objects
 
 clean:
 	$(MAKE) -C $(KERNELDIR) M=$(CURDIR) clean
@@ -32,5 +30,7 @@ dtb:
 	cp am335x-bone-common.dtsi $(KERNELDIR)/arch/arm/boot/dts/
 	$(MAKE) -C $(KERNELDIR) M=$(CURDIR) dtbs
 
+clean_objects:
+	rm -rf *.o *.*.o .*.cmd Module.* *.order .tmp_versions
 
 endif

--- a/mpu6050/am335x-bone-common.dtsi
+++ b/mpu6050/am335x-bone-common.dtsi
@@ -6,8 +6,6 @@
  * published by the Free Software Foundation.
  */
 
-#include <dt-bindings/mfd/tps65217.h>
-
 / {
 	cpus {
 		cpu@0 {
@@ -84,12 +82,12 @@
 		>;
 	};
 
-	i2c2_pins: pinmux_i2c2_pins {
-		pinctrl-single,pins = <
-			AM33XX_IOPAD(0x978, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_ctsn.i2c2_sda */
-			AM33XX_IOPAD(0x97c, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_rtsn.i2c2_scl */
-		>;
-	};
+//	i2c2_pins: pinmux_i2c2_pins {
+//		pinctrl-single,pins = <
+//			AM33XX_IOPAD(0x978, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_ctsn.i2c2_sda */
+//			AM33XX_IOPAD(0x97c, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_rtsn.i2c2_scl */
+//		>;
+//	};
 
 	uart0_pins: pinmux_uart0_pins {
 		pinctrl-single,pins = <
@@ -176,6 +174,46 @@
 			AM33XX_IOPAD(0x81c, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad7.mmc1_dat7 */
 		>;
 	};
+
+	/* P9_19 (ZCZ ball D17) i2c */
+	P9_19_default_pin: pinmux_P9_19_default_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* uart1_rtsn.i2c2_scl */
+	P9_19_gpio_pin: pinmux_P9_19_gpio_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x097c, PIN_OUTPUT | INPUT_EN | MUX_MODE7) >; };	/* uart1_rtsn.gpio0_13 */
+	P9_19_gpio_pu_pin: pinmux_P9_19_gpio_pu_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE7) >; };	/* uart1_rtsn.gpio0_13 */
+	P9_19_gpio_pd_pin: pinmux_P9_19_gpio_pd_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* uart1_rtsn.gpio0_13 */
+	P9_19_spi_cs_pin: pinmux_P9_19_spi_cs_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE4) >; };	/* uart1_rtsn.spi1_cs1 */
+	P9_19_i2c_pin: pinmux_P9_19_i2c_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* uart1_rtsn.i2c2_scl */
+	P9_19_can_pin: pinmux_P9_19_can_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x097c, PIN_INPUT_PULLUP | MUX_MODE2) >; };		/* uart1_rtsn.dcan0_rx */
+	P9_19_pru_uart_pin: pinmux_P9_19_pru_uart_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE5) >; };	/* uart1_rtsn.pr1_uart0_rts_n */
+	P9_19_timer_pin: pinmux_P9_19_timer_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE1) >; };	/* uart1_rtsn.timer5 */
+
+	/* P9_20 (ZCZ ball D18) i2c */
+	P9_20_default_pin: pinmux_P9_20_default_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* uart1_ctsn.i2c2_sda */
+	P9_20_gpio_pin: pinmux_P9_20_gpio_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x0978, PIN_OUTPUT | INPUT_EN | MUX_MODE7) >; };	/* uart1_ctsn.gpio0_12 */
+	P9_20_gpio_pu_pin: pinmux_P9_20_gpio_pu_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE7) >; };	/* uart1_ctsn.gpio0_12 */
+	P9_20_gpio_pd_pin: pinmux_P9_20_gpio_pd_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* uart1_ctsn.gpio0_12 */
+	P9_20_spi_cs_pin: pinmux_P9_20_spi_cs_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE4) >; };	/* uart1_ctsn.spi1_cs0 */
+	P9_20_i2c_pin: pinmux_P9_20_i2c_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* uart1_ctsn.i2c2_sda */
+	P9_20_can_pin: pinmux_P9_20_can_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x0978, PIN_INPUT_PULLUP | MUX_MODE2) >; };		/* uart1_ctsn.dcan0_tx */
+	P9_20_pru_uart_pin: pinmux_P9_20_pru_uart_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE5) >; };	/* uart1_ctsn.pr1_uart0_cts_n */
+	P9_20_timer_pin: pinmux_P9_20_timer_pin { pinctrl-single,pins = <
+		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE1) >; };	/* uart1_ctsn.timer6 */
 };
 
 &uart0 {
@@ -204,6 +242,8 @@
 &usb0 {
 	status = "okay";
 	dr_mode = "peripheral";
+	interrupts-extended = <&intc 18 &tps 0>;
+	interrupt-names = "mc", "vbus";
 };
 
 &usb1 {
@@ -227,7 +267,7 @@
 	};
 
 	baseboard_eeprom: baseboard_eeprom@50 {
-		compatible = "at,24c256";
+		compatible = "atmel,24c256";
 		reg = <0x50>;
 
 		#address-cells = <1>;
@@ -240,19 +280,20 @@
 
 &i2c2 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&i2c2_pins>;
+	//pinctrl-0 = <&i2c2_pins>;
+	pinctrl-0 = <>;
 
 	status = "okay";
 	clock-frequency = <100000>;
 
-	gl_gyro: gl_gyro@68 {
-		compatible = "gl,mpu6050";
+	gyro: gyro@68 {
+		compatible = "mpu6050";
 		reg = <0x68>;
 		status = "okay";
 	};
 
 	cape_eeprom0: cape_eeprom0@54 {
-		compatible = "at,24c256";
+		compatible = "atmel,24c256";
 		reg = <0x54>;
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -262,7 +303,7 @@
 	};
 
 	cape_eeprom1: cape_eeprom1@55 {
-		compatible = "at,24c256";
+		compatible = "atmel,24c256";
 		reg = <0x55>;
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -272,7 +313,7 @@
 	};
 
 	cape_eeprom2: cape_eeprom2@56 {
-		compatible = "at,24c256";
+		compatible = "atmel,24c256";
 		reg = <0x56>;
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -282,7 +323,7 @@
 	};
 
 	cape_eeprom3: cape_eeprom3@57 {
-		compatible = "at,24c256";
+		compatible = "atmel,24c256";
 		reg = <0x57>;
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -320,13 +361,10 @@
 	ti,pmic-shutdown-controller;
 
 	charger {
-		interrupts = <TPS65217_IRQ_AC>, <TPS65217_IRQ_USB>;
-		interrupts-names = "AC", "USB";
 		status = "okay";
 	};
 
 	pwrbutton {
-		interrupts = <TPS65217_IRQ_PB>;
 		status = "okay";
 	};
 
@@ -415,27 +453,6 @@
 &rtc {
 	clocks = <&clk_32768_ck>, <&clkdiv32k_ick>;
 	clock-names = "ext-clk", "int-clk";
-	system-power-controller;
-};
-
-&wkup_m3_ipc {
-	ti,scale-data-fw = "am335x-bone-scale-data.bin";
-};
-
-&pruss_soc_bus {
-	status = "okay";
-
-	pruss: pruss@4a300000 {
-		status = "okay";
-
-		pru0: pru@4a334000 {
-			status = "okay";
-		};
-
-		pru1: pru@4a338000 {
-			status = "okay";
-		};
-	};
 };
 
 /* the cape manager */
@@ -460,5 +477,62 @@
 				compatible-name = "ti,beaglebone-black";
 			};
 		};
+	};
+};
+
+&ocp {
+	/* P9_19 (ZCZ ball D17) i2c */
+	P9_19_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "spi_cs", "can", "i2c", "pru_uart", "timer";
+		pinctrl-0 = <&P9_19_default_pin>;
+		pinctrl-1 = <&P9_19_gpio_pin>;
+		pinctrl-2 = <&P9_19_gpio_pu_pin>;
+		pinctrl-3 = <&P9_19_gpio_pd_pin>;
+		pinctrl-4 = <&P9_19_spi_cs_pin>;
+		pinctrl-5 = <&P9_19_can_pin>;
+		pinctrl-6 = <&P9_19_i2c_pin>;
+		pinctrl-7 = <&P9_19_pru_uart_pin>;
+		pinctrl-8 = <&P9_19_timer_pin>;
+	};
+
+	/* P9_20 (ZCZ ball D18) i2c */
+	P9_20_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "spi_cs", "can", "i2c", "pru_uart", "timer";
+		pinctrl-0 = <&P9_20_default_pin>;
+		pinctrl-1 = <&P9_20_gpio_pin>;
+		pinctrl-2 = <&P9_20_gpio_pu_pin>;
+		pinctrl-3 = <&P9_20_gpio_pd_pin>;
+		pinctrl-4 = <&P9_20_spi_cs_pin>;
+		pinctrl-5 = <&P9_20_can_pin>;
+		pinctrl-6 = <&P9_20_i2c_pin>;
+		pinctrl-7 = <&P9_20_pru_uart_pin>;
+		pinctrl-8 = <&P9_20_timer_pin>;
+	};
+
+
+	cape-universal {
+		compatible = "gpio-of-helper";
+		status = "okay";
+		pinctrl-names = "default";
+		pinctrl-0 = <>;
+
+		P9_19 {
+			gpio-name = "P9_19";
+			gpio = <&gpio0 13 0>;
+			input;
+			dir-changeable;
+		};
+
+		P9_20 {
+			gpio-name = "P9_20";
+			gpio = <&gpio0 12 0>;
+			input;
+			dir-changeable;
+		};
+
 	};
 };

--- a/mpu6050/mpu6050.c
+++ b/mpu6050/mpu6050.c
@@ -1,66 +1,174 @@
+#include <linux/uaccess.h>
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/device.h>
 #include <linux/err.h>
-#include <linux/i2c.h>
-#include <linux/i2c-dev.h>
-
+#include <linux/sched.h>
+#include <linux/time.h>
+#include <linux/cdev.h>
+#include <linux/kthread.h>
+#include <linux/completion.h>
 #include "mpu6050-regs.h"
+#include "mpu6050.h"
 
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Oleksii Kogutenko");
+MODULE_VERSION("1.0");
+MODULE_DESCRIPTION("Kernel training: 07 - MPU6050 mudule + cdev");
 
-struct mpu6050_data {
-	struct i2c_client *drv_client;
-	int accel_values[3];
-	int gyro_values[3];
-	int temperature;
-};
-
+// ----------------------------------------------------------------------------
 static struct mpu6050_data g_mpu6050_data;
+// ----------------------------------------------------------------------------
+static const struct i2c_device_id mpu6050_idtable[] = {
+	{ "mpu6050", 0 },
+	{ }
+};
+MODULE_DEVICE_TABLE(i2c, mpu6050_idtable);
+// ----------------------------------------------------------------------------
 
+CLASS_DATA_RO(mpu6050, accel_x, mpu6050_show);
+CLASS_DATA_RO(mpu6050, accel_y, mpu6050_show);
+CLASS_DATA_RO(mpu6050, accel_z, mpu6050_show);
+CLASS_DATA_RO(mpu6050, gyro_x, mpu6050_show);
+CLASS_DATA_RO(mpu6050, gyro_y, mpu6050_show);
+CLASS_DATA_RO(mpu6050, gyro_z, mpu6050_show);
+CLASS_DATA_RO(mpu6050, temperature, mpu6050_show);
+CLASS_DATA_RO(mpu6050, all, mpu6050_show);
+
+ATTR_GROUP(mpu6050,
+	ATTR_GROUP_EXTRA_GEN(GET_CLASS_DATA_RO_ATTR(mpu6050, accel_x),
+	ATTR_GROUP_EXTRA_GEN(GET_CLASS_DATA_RO_ATTR(mpu6050, accel_y),
+	ATTR_GROUP_EXTRA_GEN(GET_CLASS_DATA_RO_ATTR(mpu6050, accel_z),
+	ATTR_GROUP_EXTRA_GEN(GET_CLASS_DATA_RO_ATTR(mpu6050, gyro_x),
+	ATTR_GROUP_EXTRA_GEN(GET_CLASS_DATA_RO_ATTR(mpu6050, gyro_y),
+	ATTR_GROUP_EXTRA_GEN(GET_CLASS_DATA_RO_ATTR(mpu6050, gyro_z),
+	ATTR_GROUP_EXTRA_GEN(GET_CLASS_DATA_RO_ATTR(mpu6050, temperature),
+	ATTR_GROUP_EXTRA_GEN(GET_CLASS_DATA_RO_ATTR(mpu6050, all),
+		NULL
+	))))))))
+)
+
+ATTR_GROUPS(mpu6050, ATTR_GET_GROUP(mpu6050))
+// ----------------------------------------------------------------------------
+struct class mpu6050_class = {
+	.name			= "mpu6050",
+	.class_groups	= ATTR_GET_GROUPS(mpu6050),
+	.owner			= THIS_MODULE,
+};
+// ----------------------------------------------------------------------------
+static struct i2c_driver mpu6050_i2c_driver = {
+	.driver = {
+		.name = "mpu6050",
+	},
+
+	.probe = mpu6050_probe,
+	.remove = mpu6050_remove,
+	.id_table = mpu6050_idtable,
+};
+// ----------------------------------------------------------------------------
+static struct {
+	struct timer_list	timer;
+	spinlock_t			lock;
+} timer;
+// ----------------------------------------------------------------------------
+static struct cdev mpu6050_dev;
+static const struct file_operations mpu6050_dev_fops = {
+	.owner = THIS_MODULE,
+	.read  = mpu6050_dev_read,
+};
+static int major;
+module_param(major, int, 0444);
+struct task_struct *p_mpu6050_thread;
+DECLARE_COMPLETION(comp_one_sec);
+/* ----------------------------------------------------------------------------
+ * timer callback
+ * ----------------------------------------------------------------------------
+ */
+void timer_callback(unsigned long data)
+{
+	unsigned long flags = 0;
+	u64 jiff, diff;
+
+	spin_lock_irqsave(&timer.lock, flags);
+
+	jiff = get_jiffies_64();
+	diff = (jiff - timer.timer.expires) + TIMER_PERIOD + jiff;
+
+	mod_timer(&timer.timer, diff);
+
+	spin_unlock_irqrestore(&timer.lock, flags);
+	complete(&comp_one_sec);
+}
+/* ----------------------------------------------------------------------------
+ * init_driver_timer
+ * ----------------------------------------------------------------------------
+ */
+static int init_driver_timer(void)
+{
+	int ret = 0;
+
+	spin_lock_init(&timer.lock);
+	init_timer(&timer.timer);
+	setup_timer(&timer.timer, timer_callback, 0);
+	ret = mod_timer(&timer.timer, get_jiffies_64() + TIMER_PERIOD);
+
+	return ret;
+}
+/* ---------------------------------------------------------------------------
+ * deinit_driver_timer
+ * ---------------------------------------------------------------------------
+ */
+static void deinit_driver_timer(void)
+{
+	del_timer(&timer.timer);
+}
+/* ---------------------------------------------------------------------------
+ * mpu6050_read_data
+ * ---------------------------------------------------------------------------
+ */
+#define I2C_READ(client, addr) \
+	(s16)((u16)i2c_smbus_read_word_swapped(client, addr))
 static int mpu6050_read_data(void)
 {
-	int temp;
+	unsigned long flags;
+	int data[NUM_MPU6050_DATA];
 	struct i2c_client *drv_client = g_mpu6050_data.drv_client;
+	int counter;
 
 	if (drv_client == 0)
 		return -ENODEV;
 
-	/* accel */
-	g_mpu6050_data.accel_values[0] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_ACCEL_XOUT_H));
-	g_mpu6050_data.accel_values[1] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_ACCEL_YOUT_H));
-	g_mpu6050_data.accel_values[2] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_ACCEL_ZOUT_H));
-	/* gyro */
-	g_mpu6050_data.gyro_values[0] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_GYRO_XOUT_H));
-	g_mpu6050_data.gyro_values[1] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_GYRO_YOUT_H));
-	g_mpu6050_data.gyro_values[2] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_GYRO_ZOUT_H));
+	data[0] = I2C_READ(drv_client, REG_ACCEL_XOUT_H);
+	data[1] = I2C_READ(drv_client, REG_ACCEL_YOUT_H);
+	data[2] = I2C_READ(drv_client, REG_ACCEL_ZOUT_H);
+	data[3] = I2C_READ(drv_client, REG_GYRO_XOUT_H);
+	data[4] = I2C_READ(drv_client, REG_GYRO_YOUT_H);
+	data[5] = I2C_READ(drv_client, REG_GYRO_ZOUT_H);
+	data[6] = I2C_READ(drv_client, REG_TEMP_OUT_H);
 	/* Temperature in degrees C =
 	 * (TEMP_OUT Register Value  as a signed quantity)/340 + 36.53
 	 */
-	temp = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_TEMP_OUT_H));
-	g_mpu6050_data.temperature = (temp + 12420 + 170) / 340;
+	data[6] = (data[6] + 12420 + 170) / 340;
 
-	dev_info(&drv_client->dev, "sensor data read:\n");
-	dev_info(&drv_client->dev, "ACCEL[X,Y,Z] = [%d, %d, %d]\n",
-		g_mpu6050_data.accel_values[0],
-		g_mpu6050_data.accel_values[1],
-		g_mpu6050_data.accel_values[2]);
-	dev_info(&drv_client->dev, "GYRO[X,Y,Z] = [%d, %d, %d]\n",
-		g_mpu6050_data.gyro_values[0],
-		g_mpu6050_data.gyro_values[1],
-		g_mpu6050_data.gyro_values[2]);
-	dev_info(&drv_client->dev, "TEMP = %d\n",
-		g_mpu6050_data.temperature);
+	spin_lock_irqsave(&g_mpu6050_data.lock, flags);
+	memcpy(g_mpu6050_data.data, data, sizeof(data));
+	counter = g_mpu6050_data.counter++;
+	spin_unlock_irqrestore(&g_mpu6050_data.lock, flags);
 
+	//dev_info(&drv_client->dev, "sensor data read %d:\n", counter);
 	return 0;
 }
-
+/* ---------------------------------------------------------------------------
+ * mpu6050_probe
+ * ---------------------------------------------------------------------------
+ */
 static int mpu6050_probe(struct i2c_client *drv_client,
 			 const struct i2c_device_id *id)
 {
 	int ret;
 
 	dev_info(&drv_client->dev,
-		"i2c client address is 0x%X\n", drv_client->addr);
+			"i2c client address is 0x%X\n", drv_client->addr);
 
 	/* Read who_am_i register */
 	ret = i2c_smbus_read_byte_data(drv_client, REG_WHO_AM_I);
@@ -97,108 +205,132 @@ static int mpu6050_probe(struct i2c_client *drv_client,
 	dev_info(&drv_client->dev, "i2c driver probed\n");
 	return 0;
 }
-
+/* ---------------------------------------------------------------------------
+ * mpu6050_remove
+ * ---------------------------------------------------------------------------
+ */
 static int mpu6050_remove(struct i2c_client *drv_client)
 {
-	g_mpu6050_data.drv_client = 0;
+	g_mpu6050_data.drv_client = NULL;
 
 	dev_info(&drv_client->dev, "i2c driver removed\n");
 	return 0;
 }
-
-static const struct i2c_device_id mpu6050_idtable[] = {
-	{ "mpu6050", 0 },
-	{ }
-};
-MODULE_DEVICE_TABLE(i2c, mpu6050_idtable);
-
-static struct i2c_driver mpu6050_i2c_driver = {
-	.driver = {
-		.name = "gl_mpu6050",
-	},
-
-	.probe = mpu6050_probe,
-	.remove = mpu6050_remove,
-	.id_table = mpu6050_idtable,
-};
-
-static ssize_t accel_x_show(struct class *class,
-			    struct class_attribute *attr, char *buf)
+/* ---------------------------------------------------------------------------
+ * mpu6050_show
+ * ---------------------------------------------------------------------------
+ */
+static ssize_t mpu6050_show(struct class *class, struct class_attribute *attr,
+		char *buf)
 {
-	mpu6050_read_data();
+	unsigned long flags;
+	int data[NUM_MPU6050_DATA];
+	const char *name = attr->attr.name;
+	int counter;
 
-	sprintf(buf, "%d\n", g_mpu6050_data.accel_values[0]);
+	spin_lock_irqsave(&g_mpu6050_data.lock, flags);
+	memcpy(data, g_mpu6050_data.data, sizeof(data));
+	counter = g_mpu6050_data.counter;
+	spin_unlock_irqrestore(&g_mpu6050_data.lock, flags);
+
+	pr_info("[%s]:: attr.name:%s\n", __func__, name);
+
+	if (!strcmp(name, "all")) {
+		sprintf(buf,
+				"\n\taccel:\t {%d, %d, %d}\n\tgyro:\t {%d, %d, %d}\n\ttemperature:\t %d\n\tcounter:\t %d\n",
+				data[0], data[1], data[2],
+				data[3], data[4], data[5],
+				data[6], counter
+				);
+	} else if (!strcmp(name, "temperature"))
+		sprintf(buf, "%d\n", data[6]);
+	else if (!strcmp(name, "gyro_z"))
+		sprintf(buf, "%d\n", data[5]);
+	else if (!strcmp(name, "gyro_y"))
+		sprintf(buf, "%d\n", data[4]);
+	else if (!strcmp(name, "gyro_x"))
+		sprintf(buf, "%d\n", data[3]);
+	else if (!strcmp(name, "accel_z"))
+		sprintf(buf, "%d\n", data[2]);
+	else if (!strcmp(name, "accel_y"))
+		sprintf(buf, "%d\n", data[1]);
+	else if (!strcmp(name, "accel_x"))
+		sprintf(buf, "%d\n", data[0]);
+
 	return strlen(buf);
 }
-
-static ssize_t accel_y_show(struct class *class,
-			    struct class_attribute *attr, char *buf)
+/* ---------------------------------------------------------------------------
+ * work_func
+ * ---------------------------------------------------------------------------
+ */
+static int mpu6050_thread(void *param)
 {
-	mpu6050_read_data();
-
-	sprintf(buf, "%d\n", g_mpu6050_data.accel_values[1]);
-	return strlen(buf);
+	pr_info("[%s]+++\n", __func__);
+	while (!kthread_should_stop()) {
+		if (wait_for_completion_timeout(&comp_one_sec, TIMER_PERIOD))
+			mpu6050_read_data();
+	}
+	pr_info("[%s]---\n", __func__);
+	return 0;
 }
-
-static ssize_t accel_z_show(struct class *class,
-			    struct class_attribute *attr, char *buf)
+/* ---------------------------------------------------------------------------
+ * mpu6050_dev_read
+ * ---------------------------------------------------------------------------
+ */
+static ssize_t mpu6050_dev_read(struct file *file, char *buf, size_t count,
+		loff_t *ppos)
 {
-	mpu6050_read_data();
+	unsigned long flags;
+	int data[NUM_MPU6050_DATA];
+	char buf_str[65];
+	size_t buf_len = 0;
+	int counter = 0;
+	static int prev_counter;
 
-	sprintf(buf, "%d\n", g_mpu6050_data.accel_values[2]);
-	return strlen(buf);
+	pr_info("[%s] (%p, %p, %d, %p(%lld))\n", __func__,
+			file, buf, count, ppos, (ppos) ? *ppos : 0);
+	spin_lock_irqsave(&g_mpu6050_data.lock, flags);
+	memcpy(data, g_mpu6050_data.data, sizeof(data));
+	counter = g_mpu6050_data.counter;
+	spin_unlock_irqrestore(&g_mpu6050_data.lock, flags);
+
+	if (counter == prev_counter) {
+		pr_info("Reading avoid: %d\n", counter);
+		return 0;
+	}
+	prev_counter = counter;
+
+	snprintf(buf_str, sizeof(buf_str) - 1,
+			"%d, %d, %d, %d, %d, %d, %d\n",
+			data[0], data[1], data[2],
+			data[3], data[4], data[5],
+			data[6]
+			);
+	buf_len = strlen(buf_str);
+
+	if (buf_len > count) {
+		pr_err("Reading more lengths .... (%d > %d)\n", buf_len, count);
+		return -EINVAL;
+	}
+
+	if (copy_to_user(buf, buf_str, buf_len))
+		return -EINVAL;
+
+	if (ppos)
+		*ppos += buf_len;
+
+	return buf_len;
 }
-
-static ssize_t gyro_x_show(struct class *class,
-			   struct class_attribute *attr, char *buf)
-{
-	mpu6050_read_data();
-
-	sprintf(buf, "%d\n", g_mpu6050_data.gyro_values[0]);
-	return strlen(buf);
-}
-
-static ssize_t gyro_y_show(struct class *class,
-			   struct class_attribute *attr, char *buf)
-{
-	mpu6050_read_data();
-
-	sprintf(buf, "%d\n", g_mpu6050_data.gyro_values[1]);
-	return strlen(buf);
-}
-
-static ssize_t gyro_z_show(struct class *class,
-			   struct class_attribute *attr, char *buf)
-{
-	mpu6050_read_data();
-
-	sprintf(buf, "%d\n", g_mpu6050_data.gyro_values[2]);
-	return strlen(buf);
-}
-
-static ssize_t temp_show(struct class *class,
-			 struct class_attribute *attr, char *buf)
-{
-	mpu6050_read_data();
-
-	sprintf(buf, "%d\n", g_mpu6050_data.temperature);
-	return strlen(buf);
-}
-
-CLASS_ATTR(accel_x, 0444, &accel_x_show, NULL);
-CLASS_ATTR(accel_y, 0444, &accel_y_show, NULL);
-CLASS_ATTR(accel_z, 0444, &accel_z_show, NULL);
-CLASS_ATTR(gyro_x, 0444, &gyro_x_show, NULL);
-CLASS_ATTR(gyro_y, 0444, &gyro_y_show, NULL);
-CLASS_ATTR(gyro_z, 0444, &gyro_z_show, NULL);
-CLASS_ATTR(temperature, 0444, &temp_show, NULL);
-
-static struct class *attr_class;
-
+/* ---------------------------------------------------------------------------
+ * mpu6050_init
+ * ---------------------------------------------------------------------------
+ */
 static int mpu6050_init(void)
 {
 	int ret;
+	dev_t dev;
 
+	memset(&g_mpu6050_data, 0, sizeof(g_mpu6050_data));
 	/* Create i2c driver */
 	ret = i2c_add_driver(&mpu6050_i2c_driver);
 	if (ret) {
@@ -207,90 +339,78 @@ static int mpu6050_init(void)
 	}
 	pr_info("mpu6050: i2c driver created\n");
 
-	/* Create class */
-	attr_class = class_create(THIS_MODULE, "mpu6050");
-	if (IS_ERR(attr_class)) {
-		ret = PTR_ERR(attr_class);
-		pr_err("mpu6050: failed to create sysfs class: %d\n", ret);
-		return ret;
-	}
-	pr_info("mpu6050: sysfs class created\n");
-
-	/* Create accel_x */
-	ret = class_create_file(attr_class, &class_attr_accel_x);
+	ret = class_register(&mpu6050_class);
 	if (ret) {
-		pr_err("mpu6050: failed to create sysfs class attribute accel_x: %d\n", ret);
-		return ret;
-	}
-	/* Create accel_y */
-	ret = class_create_file(attr_class, &class_attr_accel_y);
-	if (ret) {
-		pr_err("mpu6050: failed to create sysfs class attribute accel_y: %d\n", ret);
-		return ret;
-	}
-	/* Create accel_z */
-	ret = class_create_file(attr_class, &class_attr_accel_z);
-	if (ret) {
-		pr_err("mpu6050: failed to create sysfs class attribute accel_z: %d\n", ret);
-		return ret;
-	}
-	/* Create gyro_x */
-	ret = class_create_file(attr_class, &class_attr_gyro_x);
-	if (ret) {
-		pr_err("mpu6050: failed to create sysfs class attribute gyro_x: %d\n", ret);
-		return ret;
-	}
-	/* Create gyro_y */
-	ret = class_create_file(attr_class, &class_attr_gyro_y);
-	if (ret) {
-		pr_err("mpu6050: failed to create sysfs class attribute gyro_y: %d\n", ret);
-		return ret;
-	}
-	/* Create gyro_z */
-	ret = class_create_file(attr_class, &class_attr_gyro_z);
-	if (ret) {
-		pr_err("mpu6050: failed to create sysfs class attribute gyro_z: %d\n", ret);
-		return ret;
-	}
-	/* Create temperature */
-	ret = class_create_file(attr_class, &class_attr_temperature);
-	if (ret) {
-		pr_err("mpu6050: failed to create sysfs class attribute temperature: %d\n", ret);
-		return ret;
+		pr_err("Unable to register mpu6050_class class\n");
+		goto err;
 	}
 
+	ret = alloc_chrdev_region(&dev, 0, 1, "mpu6050");
+	major = MAJOR(dev);
+	if (ret < 0) {
+		pr_err("mpu6050: can not register char device\n");
+		goto alloc_chrdev_err;
+	}
+
+	cdev_init(&mpu6050_dev, &mpu6050_dev_fops);
+	mpu6050_dev.owner = THIS_MODULE;
+
+	ret = cdev_add(&mpu6050_dev, dev, 1);
+	if (ret < 0) {
+		unregister_chrdev_region(MKDEV(major, 0), 1);
+		pr_err("mpu6050: can not add char device\n");
+		goto alloc_chrdev_err;
+	}
+
+	device_create(&mpu6050_class, NULL, dev, NULL, "mpu6050_x");
+
+	ret = init_driver_timer();
+	if (ret) {
+		pr_err("Unable to init timer: %d\n", ret);
+		goto create_class_err;
+	}
 	pr_info("mpu6050: sysfs class attributes created\n");
 
-	pr_info("mpu6050: module loaded\n");
-	return 0;
-}
+	p_mpu6050_thread = kthread_run(mpu6050_thread, NULL, "mpu6050_thread");
 
+	pr_info("mpu6050: module loaded\n");
+
+	return ret;
+alloc_chrdev_err:
+create_class_err:
+err:
+	i2c_del_driver(&mpu6050_i2c_driver);
+	return ret;
+}
+/* ---------------------------------------------------------------------------
+ * mpu6050_exit
+ * ---------------------------------------------------------------------------
+ */
 static void mpu6050_exit(void)
 {
-	if (attr_class) {
-		class_remove_file(attr_class, &class_attr_accel_x);
-		class_remove_file(attr_class, &class_attr_accel_y);
-		class_remove_file(attr_class, &class_attr_accel_z);
-		class_remove_file(attr_class, &class_attr_gyro_x);
-		class_remove_file(attr_class, &class_attr_gyro_y);
-		class_remove_file(attr_class, &class_attr_gyro_z);
-		class_remove_file(attr_class, &class_attr_temperature);
-		pr_info("mpu6050: sysfs class attributes removed\n");
+	dev_t dev;
 
-		class_destroy(attr_class);
-		pr_info("mpu6050: sysfs class destroyed\n");
-	}
+	kthread_stop(p_mpu6050_thread);
+
+	deinit_driver_timer();
+
+	dev = MKDEV(major, 0);
+	device_destroy(&mpu6050_class, dev);
+	cdev_del(&mpu6050_dev);
+	unregister_chrdev_region(MKDEV(major, 0), 1);
+
+	class_unregister(&mpu6050_class);
+	pr_info("mpu6050: sysfs class destroyed\n");
 
 	i2c_del_driver(&mpu6050_i2c_driver);
 	pr_info("mpu6050: i2c driver deleted\n");
 
 	pr_info("mpu6050: module exited\n");
 }
+/* ---------------------------------------------------------------------------
+ *
+ * ---------------------------------------------------------------------------
+ */
 
 module_init(mpu6050_init);
 module_exit(mpu6050_exit);
-
-MODULE_AUTHOR("Andriy.Khulap <andriy.khulap@globallogic.com>");
-MODULE_DESCRIPTION("mpu6050 I2C acc&gyro");
-MODULE_LICENSE("GPL");
-MODULE_VERSION("0.1");

--- a/mpu6050/mpu6050.h
+++ b/mpu6050/mpu6050.h
@@ -1,0 +1,76 @@
+#ifndef __MPU6060__H__
+#define __MPU6060__H__
+#include <linux/i2c.h>
+#include <linux/i2c-dev.h>
+
+#define NUM_MPU6050_DATA 7
+struct mpu6050_data {
+	struct i2c_client *drv_client;
+	union {
+		struct {
+			int accel_values[3];
+			int gyro_values[3];
+			int temperature;
+		};
+		int data[NUM_MPU6050_DATA];
+	};
+	spinlock_t	lock;
+	int counter;	//counter of reading from device
+};
+
+/* 0.5 sec */
+#define TIMER_PERIOD   ((1 * HZ)/2)
+
+#define CLASS__ATTR_RO(_name, _data, func) {\
+	.attr	= {\
+		.name = __stringify(_data),\
+		.mode = 0444\
+	},\
+	.show	= func,\
+}
+
+#define CLASS_DATA_RO(name, data, func)\
+	struct class_attribute class_attr_##name##data =\
+		CLASS__ATTR_RO(name, data, func);
+
+#define GET_CLASS_DATA_RO_ATTR(name, data)\
+	class_attr_##name##data.attr
+
+#define ATTR_GROUP_EXTRA_GEN(current, next)\
+	&current,\
+	next
+
+#define ATTR_GROUP(_name, attr_extra)\
+	static struct attribute *attrs_##_name##_extra[] = {\
+		attr_extra\
+	};\
+	static struct attribute_group group_##_name = {\
+		.attrs =  attrs_##_name##_extra,\
+	};
+
+#define ATTR_GROUPS(name, attr_group)\
+	static const struct attribute_group *groups_##name[] = {\
+		&attr_group,\
+		NULL\
+	};
+
+#define ATTR_GET_GROUP(name)\
+	group_##name
+#define ATTR_GET_GROUPS(name)\
+	groups_##name
+
+static int mpu6050_read_data(void);
+static int mpu6050_probe(struct i2c_client *drv_client,
+			 const struct i2c_device_id *id);
+static int mpu6050_remove(struct i2c_client *drv_client);
+static ssize_t mpu6050_show(struct class *class, struct class_attribute *attr,
+		char *buf);
+static int mpu6050_init(void);
+static void mpu6050_exit(void);
+static void timer_callback(unsigned long data);
+static int init_driver_timer(void);
+static void deinit_driver_timer(void);
+static ssize_t mpu6050_dev_read(struct file *file, char *buf, size_t count,
+		loff_t *ppos);
+static int mpu6050_thread(void *param);
+#endif


### PR DESCRIPTION
Compact initialization of mpu6050 driver.

 - use one class structure for all internal files
 - use one show function for all class files
 - use dtsi file from 4.14 kernel branch
 - cdev device added
 - use kthread_run to read i2c data
 - use timer callback to allow reading i2c data
 - use wait_for_completion to sync timer with thread
 - use spin_lock_irqsave to lock read/write data area

Signed-off-by: oleksii-kogutenko <oleksii.kogutenko@gmail.com>