### PR TITLE
ssd1306 device driver example

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+export CROSS_COMPILE=${HOME}/BBB/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
+
+export TRAINING_ROOT=${HOME}/sandbox/sandbox
+
+export BUILD_KERNEL=${HOME}/BBB/bb_kernel
+#export BUILD_ROOTFS=${TRAINING_ROOT}/rootfs
+
+#export KERNEL_IMG=${BUILD_KERNEL}/arch/x86/boot/bzImage
+#export ROOTFS_IMG=${TRAINING_ROOT}/rootfs.img
+
+echo -e "\t CROSS_COMPILE \t = ${CROSS_COMPILE}"
+echo -e "\t TRAINING_ROOT \t = ${TRAINING_ROOT}"
+echo -e "\t BUILD_KERNEL \t = ${BUILD_KERNEL}"
+#echo -e "\t BUILD_ROOTFS \t = ${BUILD_ROOTFS}"
+
+#cp ${BUILD_ROOTFS}/images/rootfs.ext2 ${TRAINING_ROOT}/rootfs.img
+#qemu-system-i386 -kernel ${KERNEL_IMG} -append "root=/dev/sda" -hda ${ROOTFS_IMG} -redir tcp:8022::22 &

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -4,7 +4,7 @@ export CROSS_COMPILE=${HOME}/BBB/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnuea
 
 export TRAINING_ROOT=${HOME}/sandbox/sandbox
 
-export BUILD_KERNEL=${HOME}/BBB/bb_kernel
+export BBB_KERNEL=${HOME}/BBB/bb_kernel
 #export BUILD_ROOTFS=${TRAINING_ROOT}/rootfs
 
 #export KERNEL_IMG=${BUILD_KERNEL}/arch/x86/boot/bzImage
@@ -12,7 +12,7 @@ export BUILD_KERNEL=${HOME}/BBB/bb_kernel
 
 echo -e "\t CROSS_COMPILE \t = ${CROSS_COMPILE}"
 echo -e "\t TRAINING_ROOT \t = ${TRAINING_ROOT}"
-echo -e "\t BUILD_KERNEL \t = ${BUILD_KERNEL}"
+echo -e "\t BBB_KERNEL \t = ${BBB_KERNEL}"
 #echo -e "\t BUILD_ROOTFS \t = ${BUILD_ROOTFS}"
 
 #cp ${BUILD_ROOTFS}/images/rootfs.ext2 ${TRAINING_ROOT}/rootfs.img

--- a/ssd1306/Makefile
+++ b/ssd1306/Makefile
@@ -1,0 +1,22 @@
+CONFIG_MODULE_SIG=n
+
+obj-m := ssd1306.o
+
+KDIR ?= ${HOME}/BBB/bb_kernel/
+#KDIR ?= ~/BBB/KERNEL/
+
+PWD := $(shell pwd)
+
+default:
+		  $(MAKE) ARCH=arm  -C $(KDIR) M=$(PWD) modules
+
+clean:
+		  $(MAKE) ARCH=arm  -C $(KDIR) SUBDIRS=$(PWD) clean
+
+config:
+		$(MAKE) ARCH=arm -C $(KDIR) menuconfig
+
+dtb:
+		$(MAKE) ARCH=arm -C $(KDIR) dtbs
+
+.PHONY: clean default config dtb

--- a/ssd1306/Makefile
+++ b/ssd1306/Makefile
@@ -2,8 +2,9 @@ CONFIG_MODULE_SIG=n
 
 obj-m := ssd1306.o
 
-KDIR ?= ${HOME}/BBB/bb_kernel/
-#KDIR ?= ~/BBB/KERNEL/
+CROSS_COMPILE ?= arm-linux-gnueabihf-
+
+KDIR ?= ${BBB_KERNEL}
 
 PWD := $(shell pwd)
 

--- a/ssd1306/README.md
+++ b/ssd1306/README.md
@@ -1,0 +1,7 @@
+## ssd1306
+A custom Linux Kernel module for the SSD1306 based 128x64 pixel OLED display.
+These displays are small, only about 1" diameter, but very readable due to the high contrast of an OLED display. This display is made of 128x64 individual white OLED pixels, each one is turned on or off by the controller chip. Because the display makes its own light, no backlight is required. 
+SSD1306 communicates via I2C serial interface.
+[DataSheet](https://www.olimex.com/Products/Modules/LCD/MOD-OLED-128x64/resources/SSD1306.pdf)
+
+![alt tag](https://www.mathworks.com/help/supportpkg/beagleboneio/ug/beaglebone_black_pinmap.png)

--- a/ssd1306/am335x-bone-common.dtsi
+++ b/ssd1306/am335x-bone-common.dtsi
@@ -226,16 +226,6 @@
 		reg = <0x24>;
 	};
 
-	baseboard_eeprom: baseboard_eeprom@50 {
-		compatible = "at,24c256";
-		reg = <0x50>;
-
-		#address-cells = <1>;
-		#size-cells = <1>;
-		baseboard_data: baseboard_data@0 {
-			reg = <0 0x100>;
-		};
-	};
 };
 
 &i2c2 {
@@ -249,8 +239,8 @@
 		compatible = "DAndy,lcd_ssd1306";
 		reg = <0x3c>;
 		status = "okay";
-	};
 
+<<<<<<< HEAD
 	cape_eeprom0: cape_eeprom0@54 {
 		compatible = "at,24c256";
 		reg = <0x54>;
@@ -290,6 +280,10 @@
 			reg = <0 0x100>;
 		};
 	};
+||||||| parent of a2bfed6... ssd1306: added I2C communications to LCD
+=======
+	};
+>>>>>>> a2bfed6... ssd1306: added I2C communications to LCD
 };
 
 

--- a/ssd1306/am335x-bone-common.dtsi
+++ b/ssd1306/am335x-bone-common.dtsi
@@ -84,6 +84,14 @@
 		>;
 	};
 
+
+	i2c1_pins: pinmux_i2c1_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x958, PIN_INPUT_PULLUP | MUX_MODE2)	/* i2c1_scl.i2c1_scl */
+			AM33XX_IOPAD(0x95c, PIN_INPUT_PULLUP | MUX_MODE2)	/* i2c1_sda.i2c1_sda */
+		>;
+	};
+
 	i2c2_pins: pinmux_i2c2_pins {
 		pinctrl-single,pins = <
 			AM33XX_IOPAD(0x978, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_ctsn.i2c2_sda */
@@ -228,12 +236,14 @@
 
 };
 
-&i2c2 {
+
+&i2c1 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&i2c2_pins>;
+	pinctrl-0 = <&i2c1_pins>;
 
 	status = "okay";
 	clock-frequency = <400000>;
+
 
 	lcd_ssd1306: lcd_ssd1306@3c {
 		compatible = "DAndy,lcd_ssd1306";
@@ -284,6 +294,16 @@
 =======
 	};
 >>>>>>> a2bfed6... ssd1306: added I2C communications to LCD
+};
+
+
+&i2c2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2_pins>;
+
+	status = "okay";
+	clock-frequency = <400000>;
+
 };
 
 

--- a/ssd1306/am335x-bone-common.dtsi
+++ b/ssd1306/am335x-bone-common.dtsi
@@ -1,0 +1,464 @@
+/*
+ * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <dt-bindings/mfd/tps65217.h>
+
+/ {
+	cpus {
+		cpu@0 {
+			cpu0-supply = <&dcdc2_reg>;
+		};
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>; /* 256 MB */
+	};
+
+	chosen {
+		stdout-path = &uart0;
+	};
+
+	leds {
+		pinctrl-names = "default";
+		pinctrl-0 = <&user_leds_s0>;
+
+		compatible = "gpio-leds";
+
+		led2 {
+			label = "beaglebone:green:usr0";
+			gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+			default-state = "off";
+		};
+
+		led3 {
+			label = "beaglebone:green:usr1";
+			gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mmc0";
+			default-state = "off";
+		};
+
+		led4 {
+			label = "beaglebone:green:usr2";
+			gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "cpu0";
+			default-state = "off";
+		};
+
+		led5 {
+			label = "beaglebone:green:usr3";
+			gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mmc1";
+			default-state = "off";
+		};
+	};
+
+	vmmcsd_fixed: fixedregulator0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vmmcsd_fixed";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+	};
+};
+
+&am33xx_pinmux {
+	user_leds_s0: user_leds_s0 {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x854, PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a5.gpio1_21 */
+			AM33XX_IOPAD(0x858, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* gpmc_a6.gpio1_22 */
+			AM33XX_IOPAD(0x85c, PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a7.gpio1_23 */
+			AM33XX_IOPAD(0x860, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* gpmc_a8.gpio1_24 */
+		>;
+	};
+
+	i2c0_pins: pinmux_i2c0_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x988, PIN_INPUT_PULLUP | MUX_MODE0)	/* i2c0_sda.i2c0_sda */
+			AM33XX_IOPAD(0x98c, PIN_INPUT_PULLUP | MUX_MODE0)	/* i2c0_scl.i2c0_scl */
+		>;
+	};
+
+	i2c2_pins: pinmux_i2c2_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x978, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_ctsn.i2c2_sda */
+			AM33XX_IOPAD(0x97c, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_rtsn.i2c2_scl */
+		>;
+	};
+
+	uart0_pins: pinmux_uart0_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x970, PIN_INPUT_PULLUP | MUX_MODE0)	/* uart0_rxd.uart0_rxd */
+			AM33XX_IOPAD(0x974, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* uart0_txd.uart0_txd */
+		>;
+	};
+
+	cpsw_default: cpsw_default {
+		pinctrl-single,pins = <
+			/* Slave 1 */
+			0x108 (PIN_INPUT | MUX_MODE0)		/* mii1_col.mii1_col */
+			0x10c (PIN_INPUT | MUX_MODE0)		/* mii1_crs.mii1_crs */
+			AM33XX_IOPAD(0x910, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxerr.mii1_rxerr */
+			AM33XX_IOPAD(0x914, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txen.mii1_txen */
+			AM33XX_IOPAD(0x918, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxdv.mii1_rxdv */
+			AM33XX_IOPAD(0x91c, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txd3.mii1_txd3 */
+			AM33XX_IOPAD(0x920, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txd2.mii1_txd2 */
+			AM33XX_IOPAD(0x924, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txd1.mii1_txd1 */
+			AM33XX_IOPAD(0x928, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txd0.mii1_txd0 */
+			AM33XX_IOPAD(0x92c, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_txclk.mii1_txclk */
+			AM33XX_IOPAD(0x930, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxclk.mii1_rxclk */
+			AM33XX_IOPAD(0x934, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxd3.mii1_rxd3 */
+			AM33XX_IOPAD(0x938, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxd2.mii1_rxd2 */
+			AM33XX_IOPAD(0x93c, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxd1.mii1_rxd1 */
+			AM33XX_IOPAD(0x940, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxd0.mii1_rxd0 */
+		>;
+	};
+
+	cpsw_sleep: cpsw_sleep {
+		pinctrl-single,pins = <
+			/* Slave 1 reset value */
+			0x108 (PIN_INPUT_PULLDOWN | MUX_MODE7)
+			0x10c (PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x910, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x914, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x918, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x91c, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x920, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x924, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x928, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x92c, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x930, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x934, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x938, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x93c, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x940, PIN_INPUT_PULLDOWN | MUX_MODE7)
+		>;
+	};
+
+	davinci_mdio_default: davinci_mdio_default {
+		pinctrl-single,pins = <
+			/* MDIO */
+			AM33XX_IOPAD(0x948, PIN_INPUT_PULLUP | SLEWCTRL_FAST | MUX_MODE0)	/* mdio_data.mdio_data */
+			AM33XX_IOPAD(0x94c, PIN_OUTPUT_PULLUP | MUX_MODE0)			/* mdio_clk.mdio_clk */
+		>;
+	};
+
+	davinci_mdio_sleep: davinci_mdio_sleep {
+		pinctrl-single,pins = <
+			/* MDIO reset value */
+			AM33XX_IOPAD(0x948, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x94c, PIN_INPUT_PULLDOWN | MUX_MODE7)
+		>;
+	};
+
+	mmc1_pins: pinmux_mmc1_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x960, PIN_INPUT | MUX_MODE7) /* GPIO0_6 */
+		>;
+	};
+
+	emmc_pins: pinmux_emmc_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x880, PIN_INPUT_PULLUP | MUX_MODE2) /* gpmc_csn1.mmc1_clk */
+			AM33XX_IOPAD(0x884, PIN_INPUT_PULLUP | MUX_MODE2) /* gpmc_csn2.mmc1_cmd */
+			AM33XX_IOPAD(0x800, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad0.mmc1_dat0 */
+			AM33XX_IOPAD(0x804, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad1.mmc1_dat1 */
+			AM33XX_IOPAD(0x808, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad2.mmc1_dat2 */
+			AM33XX_IOPAD(0x80c, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad3.mmc1_dat3 */
+			AM33XX_IOPAD(0x810, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad4.mmc1_dat4 */
+			AM33XX_IOPAD(0x814, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad5.mmc1_dat5 */
+			AM33XX_IOPAD(0x818, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad6.mmc1_dat6 */
+			AM33XX_IOPAD(0x81c, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad7.mmc1_dat7 */
+		>;
+	};
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_ctrl_mod {
+	status = "okay";
+};
+
+&usb0_phy {
+	status = "okay";
+};
+
+&usb1_phy {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	dr_mode = "peripheral";
+};
+
+&usb1 {
+	status = "okay";
+	dr_mode = "host";
+};
+
+&cppi41dma  {
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+
+	status = "okay";
+	clock-frequency = <400000>;
+
+	tps: tps@24 {
+		reg = <0x24>;
+	};
+
+	baseboard_eeprom: baseboard_eeprom@50 {
+		compatible = "at,24c256";
+		reg = <0x50>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+		baseboard_data: baseboard_data@0 {
+			reg = <0 0x100>;
+		};
+	};
+};
+
+&i2c2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2_pins>;
+
+	status = "okay";
+	clock-frequency = <400000>;
+
+	lcd_ssd1306: lcd_ssd1306@3c {
+		compatible = "DAndy,lcd_ssd1306";
+		reg = <0x3c>;
+		status = "okay";
+	};
+
+	cape_eeprom0: cape_eeprom0@54 {
+		compatible = "at,24c256";
+		reg = <0x54>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		cape0_data: cape_data@0 {
+			reg = <0 0x100>;
+		};
+	};
+
+	cape_eeprom1: cape_eeprom1@55 {
+		compatible = "at,24c256";
+		reg = <0x55>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		cape1_data: cape_data@0 {
+			reg = <0 0x100>;
+		};
+	};
+
+	cape_eeprom2: cape_eeprom2@56 {
+		compatible = "at,24c256";
+		reg = <0x56>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		cape2_data: cape_data@0 {
+			reg = <0 0x100>;
+		};
+	};
+
+	cape_eeprom3: cape_eeprom3@57 {
+		compatible = "at,24c256";
+		reg = <0x57>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		cape3_data: cape_data@0 {
+			reg = <0 0x100>;
+		};
+	};
+};
+
+
+/include/ "tps65217.dtsi"
+
+&tps {
+	/*
+	 * Configure pmic to enter OFF-state instead of SLEEP-state ("RTC-only
+	 * mode") at poweroff.  Most BeagleBone versions do not support RTC-only
+	 * mode and risk hardware damage if this mode is entered.
+	 *
+	 * For details, see linux-omap mailing list May 2015 thread
+	 *	[PATCH] ARM: dts: am335x-bone* enable pmic-shutdown-controller
+	 * In particular, messages:
+	 *	http://www.spinics.net/lists/linux-omap/msg118585.html
+	 *	http://www.spinics.net/lists/linux-omap/msg118615.html
+	 *
+	 * You can override this later with
+	 *	&tps {  /delete-property/ ti,pmic-shutdown-controller;  }
+	 * if you want to use RTC-only mode and made sure you are not affected
+	 * by the hardware problems. (Tip: double-check by performing a current
+	 * measurement after shutdown: it should be less than 1 mA.)
+	 */
+
+	interrupts = <7>; /* NMI */
+	interrupt-parent = <&intc>;
+
+	ti,pmic-shutdown-controller;
+
+	charger {
+		interrupts = <TPS65217_IRQ_AC>, <TPS65217_IRQ_USB>;
+		interrupts-names = "AC", "USB";
+		status = "okay";
+	};
+
+	pwrbutton {
+		interrupts = <TPS65217_IRQ_PB>;
+		status = "okay";
+	};
+
+	regulators {
+		dcdc1_reg: regulator@0 {
+			regulator-name = "vdds_dpr";
+			regulator-always-on;
+		};
+
+		dcdc2_reg: regulator@1 {
+			/* VDD_MPU voltage limits 0.95V - 1.26V with +/-4% tolerance */
+			regulator-name = "vdd_mpu";
+			regulator-min-microvolt = <925000>;
+			regulator-max-microvolt = <1351500>;
+			regulator-boot-on;
+			regulator-always-on;
+		};
+
+		dcdc3_reg: regulator@2 {
+			/* VDD_CORE voltage limits 0.95V - 1.1V with +/-4% tolerance */
+			regulator-name = "vdd_core";
+			regulator-min-microvolt = <925000>;
+			regulator-max-microvolt = <1150000>;
+			regulator-boot-on;
+			regulator-always-on;
+		};
+
+		ldo1_reg: regulator@3 {
+			regulator-name = "vio,vrtc,vdds";
+			regulator-always-on;
+		};
+
+		ldo2_reg: regulator@4 {
+			regulator-name = "vdd_3v3aux";
+			regulator-always-on;
+		};
+
+		ldo3_reg: regulator@5 {
+			regulator-name = "vdd_1v8";
+			regulator-always-on;
+		};
+
+		ldo4_reg: regulator@6 {
+			regulator-name = "vdd_3v3a";
+			regulator-always-on;
+		};
+	};
+};
+
+&cpsw_emac0 {
+	phy_id = <&davinci_mdio>, <0>;
+	phy-mode = "mii";
+};
+
+&mac {
+	slaves = <1>;
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&cpsw_default>;
+	pinctrl-1 = <&cpsw_sleep>;
+	status = "okay";
+};
+
+&davinci_mdio {
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&davinci_mdio_default>;
+	pinctrl-1 = <&davinci_mdio_sleep>;
+	status = "okay";
+};
+
+&mmc1 {
+	status = "okay";
+	bus-width = <0x4>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&mmc1_pins>;
+	cd-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+};
+
+&aes {
+	status = "okay";
+};
+
+&sham {
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&clk_32768_ck>, <&clkdiv32k_ick>;
+	clock-names = "ext-clk", "int-clk";
+	system-power-controller;
+};
+
+&wkup_m3_ipc {
+	ti,scale-data-fw = "am335x-bone-scale-data.bin";
+};
+
+&pruss_soc_bus {
+	status = "okay";
+
+	pruss: pruss@4a300000 {
+		status = "okay";
+
+		pru0: pru@4a334000 {
+			status = "okay";
+		};
+
+		pru1: pru@4a338000 {
+			status = "okay";
+		};
+	};
+};
+
+/* the cape manager */
+/ {
+	bone_capemgr {
+		compatible = "ti,bone-capemgr";
+		status = "okay";
+
+		nvmem-cells = <&baseboard_data &cape0_data &cape1_data &cape2_data &cape3_data>;
+		nvmem-cell-names = "baseboard", "slot0", "slot1", "slot2", "slot3";
+		#slots = <4>;
+
+		/* map board revisions to compatible definitions */
+		baseboardmaps {
+			baseboard_beaglebone: board@0 {
+				board-name = "A335BONE";
+				compatible-name = "ti,beaglebone";
+			};
+
+			baseboard_beaglebone_black: board@1 {
+				board-name = "A335BNLT";
+				compatible-name = "ti,beaglebone-black";
+			};
+		};
+	};
+};

--- a/ssd1306/build_on_x86.sh
+++ b/ssd1306/build_on_x86.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+
+export CROSS_COMPILE=${HOME}/BBB/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
+
+MODNAME="ssd1306.ko"
+
+# parse commandline options
+while [ ! -z "$1"  ] ; do
+        case $1 in
+           -h|--help)
+                echo "TODO: help"
+                ;;
+            --clean)
+                echo "Clean module sources"
+                make ARCH=arm clean
+                ;;
+            --module)
+                echo "Build module"
+                make ARCH=arm
+                ;;
+            --deploy)
+                echo "Deploy kernel module"
+                #scp $MODNAME debian@192.168.7.2:/home/debian/
+                scp $MODNAME bbb:~/
+                scp $BUILD_KERNEL/arch/arm/boot/dts/am335x-boneblack.dtb bbb:~/
+                ;;
+            --kconfig)
+                echo "configure kernel"
+                make ARCH=arm config
+                ;;
+            
+            --dtb)
+                echo "configure kernel"
+                make ARCH=arm dtb
+                ;;
+        esac
+        shift
+done
+
+echo "Done!"

--- a/ssd1306/build_on_x86.sh
+++ b/ssd1306/build_on_x86.sh
@@ -23,6 +23,7 @@ while [ ! -z "$1"  ] ; do
                 #scp $MODNAME debian@192.168.7.2:/home/debian/
                 scp $MODNAME bbb:~/
                 scp $BUILD_KERNEL/arch/arm/boot/dts/am335x-boneblack.dtb bbb:~/
+                cp $BUILD_KERNEL/arch/arm/boot/dts/am335x-bone-common.dtsi  ./
                 ;;
             --kconfig)
                 echo "configure kernel"

--- a/ssd1306/build_on_x86.sh
+++ b/ssd1306/build_on_x86.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-export CROSS_COMPILE=${HOME}/BBB/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
-
 MODNAME="ssd1306.ko"
 
 # parse commandline options

--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -37,6 +37,21 @@ static struct ssd1306_data *lcd;
 static u8 ssd1306_Buffer[SSD1306_WIDTH * SSD1306_HEIGHT / 8];
 
 
+/**
+* @brief SSD1306 color enumeration
+*/
+typedef enum {
+        SSD1306_COLOR_BLACK = 0x00,   /*!< Black color, no pixel */
+        SSD1306_COLOR_WHITE = 0x01    /*!< Pixel is set. Color depends on LCD */
+} ssd1306_COLOR_t;
+
+
+typedef struct{
+	u16 	X;
+	u16 	Y;
+}_Point;
+
+
 /* Init sequence taken from the Adafruit SSD1306 Arduino library */
 static void ssd1306_init_lcd(struct i2c_client *drv_client) {
 
@@ -111,6 +126,93 @@ int ssd1306_UpdateScreen(struct ssd1306_data *drv_data) {
 }
 
 
+int ssd1306_DrawPixel(struct ssd1306_data *drv_data, u16 x, u16 y, ssd1306_COLOR_t color) {
+
+    if ( x >= SSD1306_WIDTH || y >= SSD1306_HEIGHT ) {
+        return -1;
+    }
+
+    /* Set color */
+    if (color == SSD1306_COLOR_WHITE) {
+        ssd1306_Buffer[x + (y / 8) * SSD1306_WIDTH] |= 1 << (y % 8);
+    }
+    else {
+        ssd1306_Buffer[x + (y / 8) * SSD1306_WIDTH] &= ~(1 << (y % 8));
+    }
+
+    return 0;
+}
+
+
+void Graphic_setPoint(const u16 X, const u16 Y)
+{
+	ssd1306_DrawPixel(lcd, X, Y, SSD1306_COLOR_WHITE);
+}
+
+
+void Graphic_drawLine(_Point p1, _Point p2){
+	int dx, dy, inx, iny, e;
+	u16 x1 = p1.X, x2 = p2.X;
+	u16 y1 = p1.Y, y2 = p2.Y;
+
+    //u16 Color = Graphic_GetForeground();
+
+    dx = x2 - x1;
+    dy = y2 - y1;
+    inx = dx > 0 ? 1 : -1;
+    iny = dy > 0 ? 1 : -1;
+
+//	dx = (u16)abs(dx);
+//    dy = (u16)abs(dy);
+    dx = (dx > 0) ? dx : -dx;
+    dy = (dy > 0) ? dy : -dy;
+
+
+    if(dx >= dy) {
+        dy <<= 1;
+        e = dy - dx;
+        dx <<= 1;
+        while (x1 != x2){
+        	Graphic_setPoint(x1, y1);//, Color);
+			if(e >= 0){
+				y1 += iny;
+				e-= dx;
+			}
+			e += dy;
+			x1 += inx;
+		}
+	}
+    else{
+		dx <<= 1;
+		e = dx - dy;
+		dy <<= 1;
+		while (y1 != y2){
+			Graphic_setPoint(x1, y1);//, Color);
+			if(e >= 0){
+				x1 += inx;
+				e -= dy;
+			}
+			e += dx;
+			y1 += iny;
+		}
+	}
+    Graphic_setPoint(x1, y1);//, Color);
+}
+// ---------------------------------------------------------------------------
+
+
+void Graphic_drawLine_(u16 x1, u16 y1, u16 x2, u16 y2){
+	_Point p1 = {0}, p2 = {0};
+	p1.X = x1;
+	p1.Y = y1;
+	p2.X = x2;
+	p2.Y = y2;
+
+	Graphic_drawLine(p1, p2);
+}
+// ---------------------------------------------------------------------------
+
+
 
 void ssd1306_clear(u8 color){
 
@@ -145,7 +247,13 @@ static ssize_t sys_lcd_paint(struct class *class,
 	i += sprintf(buf, "sys_lcd_paint\n");
 	dev_info(dev, "%s\n", __FUNCTION__);
 
-	ssd1306_clear(0xAA);
+	ssd1306_clear(0);
+
+	Graphic_drawLine_(0, 32, 127, 32);
+	Graphic_drawLine_(64, 0, 64, 64);
+
+	Graphic_drawLine_(0, 0, 127, 64);
+	Graphic_drawLine_(0, 64, 127, 0);
 
 	ssd1306_UpdateScreen(lcd);
 

--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -10,12 +10,18 @@
 #include <linux/err.h>
 
 
+#include <linux/fb.h>
+#include <linux/uaccess.h>
+
 #define DEVICE_NAME	"lcd_ssd1306"
 #define CLASS_NAME	"oled_display" 
 #define BUS_NAME	"i2c_1"
 
-#define SSD1306_WIDTH	128
-#define SSD1306_HEIGHT	64
+#define LCD_WIDTH		128
+#define LCD_HEIGHT		64	
+
+#define WRITECOMMAND	0x00 // 
+#define WRITEDATA		0x40 // 
 
 
 static struct device *dev;
@@ -25,44 +31,50 @@ static struct device *dev;
 
 struct ssd1306_data {
     struct i2c_client *client;
-	struct class *sys_class;
-    int status;
+	struct fb_info *info;
+	u32 height;
+	u32 width;
 
 	int value;
 };
-static struct ssd1306_data *lcd;
+
+
+static struct fb_fix_screeninfo ssd1307fb_fix = {
+	.id     	= "Solomon SSD1307",
+	.type       = FB_TYPE_PACKED_PIXELS,
+	.visual     = FB_VISUAL_MONO10,
+	.xpanstep   = 0,
+	.ypanstep   = 0,
+	.ywrapstep  = 0,
+	.accel      = FB_ACCEL_NONE,
+};
+
+
+static struct fb_var_screeninfo ssd1307fb_var = {
+	.bits_per_pixel = 1,
+};
 
 
 /* SSD1306 data buffer */
-static u8 ssd1306_Buffer[SSD1306_WIDTH * SSD1306_HEIGHT / 8];
+static u8 ssd1306_Buffer[LCD_WIDTH * LCD_HEIGHT / 8];
+static u8 *lcd_vmem;
 
 
-/**
-* @brief SSD1306 color enumeration
-*/
-typedef enum {
-        SSD1306_COLOR_BLACK = 0x00,   /*!< Black color, no pixel */
-        SSD1306_COLOR_WHITE = 0x01    /*!< Pixel is set. Color depends on LCD */
-} ssd1306_COLOR_t;
-
-
-typedef struct{
-	u16 	X;
-	u16 	Y;
-}_Point;
-
+int ssd1306_UpdateScreen(struct ssd1306_data *drv_data);
+int ssd1306_ON(struct ssd1306_data *drv_data);
+int ssd1306_OFF(struct ssd1306_data *drv_data);
 
 /* Init sequence taken from the Adafruit SSD1306 Arduino library */
 static void ssd1306_init_lcd(struct i2c_client *drv_client) {
 
     char m;
-    char i;
+    int i;
 
     dev_info(dev, "ssd1306: Device init \n");
-    	/* Init LCD */    
+    /* Init LCD */    
     i2c_smbus_write_byte_data(drv_client, 0x00, 0xAE); //display off
     i2c_smbus_write_byte_data(drv_client, 0x00, 0x20); //Set Memory Addressing Mode
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x10); //00,Horizontal Addressing Mode;01,Vertical Addressing Mode;10,Page Addressing Mode (RESET);11,Invalid
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0x02); //00,Horizontal Addressing Mode;01,Vertical Addressing Mode;10,Page Addressing Mode (RESET);11,Invalid
     i2c_smbus_write_byte_data(drv_client, 0x00, 0xB0); //Set Page Start Address for Page Addressing Mode,0-7
     i2c_smbus_write_byte_data(drv_client, 0x00, 0xC8); //Set COM Output Scan Direction
     i2c_smbus_write_byte_data(drv_client, 0x00, 0x00); //---set low column address
@@ -96,11 +108,10 @@ static void ssd1306_init_lcd(struct i2c_client *drv_client) {
         i2c_smbus_write_byte_data(drv_client, 0x00, 0x00);
         i2c_smbus_write_byte_data(drv_client, 0x00, 0x10);
         // Write multi data 
-        /*
-        for (i = 0; i < SSD1306_WIDTH; i++) {
+        
+        for (i = 0; i < LCD_WIDTH; i++) {
             i2c_smbus_write_byte_data(drv_client, 0x40, 0xaa);
-        }
-        */
+        }        
     }   
 }
 
@@ -117,8 +128,8 @@ int ssd1306_UpdateScreen(struct ssd1306_data *drv_data) {
         i2c_smbus_write_byte_data(drv_client, 0x00, 0x00);
         i2c_smbus_write_byte_data(drv_client, 0x00, 0x10);
         /* Write multi data */
-        for (i = 0; i < SSD1306_WIDTH; i++) {
-            i2c_smbus_write_byte_data(drv_client, 0x40, ssd1306_Buffer[SSD1306_WIDTH*m +i]);
+		for (i = 0; i < drv_data->width; i++) {
+			i2c_smbus_write_byte_data(drv_client, 0x40, ssd1306_Buffer[drv_data->width*m +i]);
         }   
     }
 
@@ -126,175 +137,137 @@ int ssd1306_UpdateScreen(struct ssd1306_data *drv_data) {
 }
 
 
-int ssd1306_DrawPixel(struct ssd1306_data *drv_data, u16 x, u16 y, ssd1306_COLOR_t color) {
+int ssd1306_ON(struct ssd1306_data *drv_data) {
+	struct i2c_client *drv_client;
 
-    if ( x >= SSD1306_WIDTH || y >= SSD1306_HEIGHT ) {
-        return -1;
-    }
+	drv_client = drv_data->client;
 
-    /* Set color */
-    if (color == SSD1306_COLOR_WHITE) {
-        ssd1306_Buffer[x + (y / 8) * SSD1306_WIDTH] |= 1 << (y % 8);
-    }
-    else {
-        ssd1306_Buffer[x + (y / 8) * SSD1306_WIDTH] &= ~(1 << (y % 8));
-    }
-
-    return 0;
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0x8D);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0x14);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0xAF);
+	return 0;
 }
 
 
-void Graphic_setPoint(const u16 X, const u16 Y)
+int ssd1306_OFF(struct ssd1306_data *drv_data) {
+	struct i2c_client *drv_client;
+
+	drv_client = drv_data->client;
+
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0x8D);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0x10);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0xAE);
+	return 0;
+}
+
+
+
+
+static void ssd1307fb_update_display(struct ssd1306_data *lcd)
 {
-	ssd1306_DrawPixel(lcd, X, Y, SSD1306_COLOR_WHITE);
-}
+	u8 *vmem = lcd->info->screen_base;
+	int i, j, k;
 
 
-void Graphic_drawLine(_Point p1, _Point p2){
-	int dx, dy, inx, iny, e;
-	u16 x1 = p1.X, x2 = p2.X;
-	u16 y1 = p1.Y, y2 = p2.Y;
-
-    //u16 Color = Graphic_GetForeground();
-
-    dx = x2 - x1;
-    dy = y2 - y1;
-    inx = dx > 0 ? 1 : -1;
-    iny = dy > 0 ? 1 : -1;
-
-//	dx = (u16)abs(dx);
-//    dy = (u16)abs(dy);
-    dx = (dx > 0) ? dx : -dx;
-    dy = (dy > 0) ? dy : -dy;
-
-
-    if(dx >= dy) {
-        dy <<= 1;
-        e = dy - dx;
-        dx <<= 1;
-        while (x1 != x2){
-        	Graphic_setPoint(x1, y1);//, Color);
-			if(e >= 0){
-				y1 += iny;
-				e-= dx;
+	for (i = 0; i < (lcd->height / 8); i++) {
+		for (j = 0; j < lcd->width; j++) {
+			u32 array_idx = i * lcd->width + j;
+			ssd1306_Buffer[array_idx] = 0;
+			for (k = 0; k < 8; k++) {
+				u32 page_length = lcd->width * i;
+				u32 index = page_length + (lcd->width * k + j) / 8;
+				u8 byte = *(vmem + index);
+				u8 bit = byte & (1 << (j % 8));
+				bit = bit >> (j % 8);
+				ssd1306_Buffer[array_idx] |= bit << k;
 			}
-			e += dy;
-			x1 += inx;
 		}
 	}
-    else{
-		dx <<= 1;
-		e = dx - dy;
-		dy <<= 1;
-		while (y1 != y2){
-			Graphic_setPoint(x1, y1);//, Color);
-			if(e >= 0){
-				x1 += inx;
-				e -= dy;
-			}
-			e += dx;
-			y1 += iny;
-		}
-	}
-    Graphic_setPoint(x1, y1);//, Color);
-}
-// ---------------------------------------------------------------------------
 
-
-void Graphic_drawLine_(u16 x1, u16 y1, u16 x2, u16 y2){
-	_Point p1 = {0}, p2 = {0};
-	p1.X = x1;
-	p1.Y = y1;
-	p2.X = x2;
-	p2.Y = y2;
-
-	Graphic_drawLine(p1, p2);
-}
-// ---------------------------------------------------------------------------
-
-
-
-void ssd1306_clear(u8 color){
-
-	memset(ssd1306_Buffer, color, sizeof(ssd1306_Buffer));
-
-	//ssd1306_UpdateScreen(lcd);
-}
-
-
-static ssize_t sys_lcd_clear(struct class *class,
-	struct class_attribute *attr, char *buf)
-{
-	//int ret;
-	ssize_t i = 0;
-
-	i += sprintf(buf, "sys_lcd_clear\n");
-	dev_info(dev, "%s\n", __FUNCTION__);
-	
-	ssd1306_clear(0);
-    ssd1306_UpdateScreen(lcd);
-
-	return i;
-}
-
-
-
-static ssize_t sys_lcd_paint(struct class *class,
-	struct class_attribute *attr, char *buf)
-{
-	ssize_t i = 0;
-
-	i += sprintf(buf, "sys_lcd_paint\n");
-	dev_info(dev, "%s\n", __FUNCTION__);
-
-	ssd1306_clear(0);
-
-	Graphic_drawLine_(0, 32, 127, 32);
-	Graphic_drawLine_(64, 0, 64, 64);
-
-	Graphic_drawLine_(0, 0, 127, 64);
-	Graphic_drawLine_(0, 64, 127, 0);
 
 	ssd1306_UpdateScreen(lcd);
-
-	return i;
 }
 
 
 
-CLASS_ATTR(clear, 0664, &sys_lcd_clear, NULL);
-CLASS_ATTR(paint, 0664, &sys_lcd_paint, NULL);
 
-
-static void make_sysfs_entry(struct i2c_client *drv_client)
+static ssize_t ssd1307fb_write(struct fb_info *info, const char __user *buf,
+		size_t count, loff_t *ppos)
 {
-	struct device_node *np = drv_client->dev.of_node;
-	const char *name;
-	int res;
+    struct ssd1306_data *lcd = info->par;
+	unsigned long total_size;
+	unsigned long p = *ppos;
+	u8 __iomem *dst;
 
-	struct class *sys_class;
+	total_size = info->fix.smem_len;
 
-	if (np) {
-		/*
-		if (!of_property_read_string(np, "label", &name))
-			dev_info(dev, "label = %s\n", name);
-		*/
+	if (p > total_size)
+		return -EINVAL;
 
-		sys_class = class_create(THIS_MODULE, DEVICE_NAME);//name);
+	if (count + p > total_size)
+		count = total_size - p;
 
-		if (IS_ERR(sys_class)){
-			dev_info(dev, "bad class create\n");
-		}
-		else{
-			res = class_create_file(sys_class, &class_attr_clear);
-			res = class_create_file(sys_class, &class_attr_paint);
+	if (!count)
+		return -EINVAL;
 
-			lcd->sys_class = sys_class;
-		}
-	}
+	dst = (void __force *) (info->screen_base + p);
 
+	if (copy_from_user(dst, buf, count))
+		return -EFAULT;
+
+	ssd1307fb_update_display(lcd);
+
+	*ppos += count;
+
+	return count;
 }
 
+static int ssd1307fb_blank(int blank_mode, struct fb_info *info)
+{
+    struct ssd1306_data *lcd = info->par;
+
+/*
+	if (blank_mode != FB_BLANK_UNBLANK)
+		return ssd1307fb_write_cmd(lcd->client, SSD1307FB_DISPLAY_OFF);
+	else
+		return ssd1307fb_write_cmd(lcd->client, SSD1307FB_DISPLAY_ON);
+*/
+    if (blank_mode != FB_BLANK_UNBLANK)
+    	return ssd1306_OFF(lcd);
+    else
+    	return ssd1306_ON(lcd);
+}
+
+static void ssd1307fb_fillrect(struct fb_info *info, const struct fb_fillrect *rect)
+{
+    struct ssd1306_data *lcd = info->par;
+	sys_fillrect(info, rect);
+	ssd1307fb_update_display(lcd);
+}
+
+static void ssd1307fb_copyarea(struct fb_info *info, const struct fb_copyarea *area)
+{
+    struct ssd1306_data *lcd = info->par;
+	sys_copyarea(info, area);
+	ssd1307fb_update_display(lcd);
+}
+
+static void ssd1307fb_imageblit(struct fb_info *info, const struct fb_image *image)
+{
+    struct ssd1306_data *lcd = info->par;
+	sys_imageblit(info, image);
+	ssd1307fb_update_display(lcd);
+}
+
+static struct fb_ops ssd1307fb_ops = {
+	.owner          = THIS_MODULE,
+	.fb_read        = fb_sys_read,
+	.fb_write       = ssd1307fb_write,
+	.fb_blank       = ssd1307fb_blank,
+	.fb_fillrect    = ssd1307fb_fillrect,
+	.fb_copyarea    = ssd1307fb_copyarea,
+	.fb_imageblit   = ssd1307fb_imageblit,
+};
 
 
 
@@ -302,61 +275,114 @@ static int ssd1306_probe(struct i2c_client *drv_client,
 			const struct i2c_device_id *id)
 {
 	struct i2c_adapter *adapter;
+	struct fb_info *info;
+	struct ssd1306_data *lcd;
+	u32 vmem_size;
+	u8 *vmem;
+	int ret;
 
 	dev = &drv_client->dev;
 
 	dev_info(dev, "init I2C driver\n");
 
 
-    lcd = devm_kzalloc(&drv_client->dev, sizeof(struct ssd1306_data),
-                        GFP_KERNEL);
-    if (!lcd)
-        return -ENOMEM;
+	info = framebuffer_alloc(sizeof(struct ssd1306_data), &drv_client->dev);
 
-    lcd->client = drv_client;
-    lcd->status = 0xABCD;
-    lcd->value 	= 10;
-
-    i2c_set_clientdata(drv_client, lcd);
-
-    adapter = drv_client->adapter;
-
-    if (!adapter)
-    {
-        dev_err(dev, "adapter indentification error\n");
-        return -ENODEV;
-    }
-
-    dev_info(dev, "I2C client address %d \n", drv_client->addr);
-
-    if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
-            dev_err(dev, "operation not supported\n");
-            return -ENODEV;
-    }
+	if (!info)
+		return -ENOMEM;
 
 
-	make_sysfs_entry(drv_client);
+	lcd = info->par;
+	lcd->info = info;
+	lcd->client = drv_client;
+
+	i2c_set_clientdata(drv_client, lcd);
+
+	adapter = drv_client->adapter;
+
+	if (!adapter)
+	{
+		dev_err(dev, "adapter indentification error\n");
+		return -ENODEV;
+	}
+
+	dev_info(dev, "I2C client address %d \n", drv_client->addr);
+
+	if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+			dev_err(dev, "operation not supported\n");
+			return -ENODEV;
+	}
+
+	lcd->info = info;
+
+	lcd->width  = LCD_WIDTH;
+	lcd->height = LCD_HEIGHT;
+
+	vmem_size = lcd->width * lcd->height / 8;
+
+	
+    lcd_vmem = devm_kzalloc(&drv_client->dev, vmem_size, GFP_KERNEL);
+
+/*	lcd_vmem = (void *)__get_free_pages(GFP_KERNEL | __GFP_ZERO,
+					get_order(vmem_size));
+*/	
+    if (!lcd_vmem) {
+		dev_err(dev, "Couldn't allocate graphical memory.\n");
+		return -ENOMEM;        
+	}
+	
+	vmem = lcd_vmem;//&ssd1306_Buffer[0];
 
 
-    ssd1306_init_lcd(drv_client);
-    //ssd1306_UpdateScreen(lcd);
+	info->fbops     = &ssd1307fb_ops;
+	info->fix       = ssd1307fb_fix;
+	info->fix.line_length = lcd->width / 8;
+	//info->fbdefio = ssd1307fb_defio;
 
-    dev_info(dev, "ssd1306 driver successfully loaded\n");
+	info->var = ssd1307fb_var;
+	info->var.xres = lcd->width;
+	info->var.xres_virtual = lcd->width;
+	info->var.yres = lcd->height;
+	info->var.yres_virtual = lcd->height;
+
+	info->var.red.length = 1;
+	info->var.red.offset = 0;
+	info->var.green.length = 1;
+	info->var.green.offset = 0;
+	info->var.blue.length = 1;
+	info->var.blue.offset = 0;
+
+	info->screen_base = (u8 __force __iomem *)vmem;
+	info->fix.smem_start = __pa(vmem);
+	info->fix.smem_len = vmem_size;
+
+
+	i2c_set_clientdata(drv_client, info);
+
+	ssd1306_init_lcd(drv_client);
+	ssd1306_UpdateScreen(lcd);
+
+
+	ret = register_framebuffer(info);
+	if (ret) {
+		dev_err(dev, "Couldn't register the framebuffer\n");
+		return ret;
+		//goto panel_init_error;
+	}    
+
+	dev_info(dev, "ssd1306 driver successfully loaded\n");
+	dev_info(dev, "DAndy fb%d: %s device registered, using %d bytes of video memory\n", info->node, info->fix.id, vmem_size);
 
 	return 0;
 }
 
 
 
-static int ssd1306_remove(struct i2c_client *client)
+static int ssd1306_remove(struct i2c_client *drv_client)
 {
-	struct class *sys_class;
+	struct fb_info *info = i2c_get_clientdata(drv_client);
 
-	sys_class = lcd->sys_class;
-
-	class_remove_file(sys_class, &class_attr_clear);
-	class_remove_file(sys_class, &class_attr_paint);
-	class_destroy(sys_class);
+	unregister_framebuffer(info);
 
 	dev_info(dev, "Goodbye, world!\n");
 	return 0;

--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -24,6 +24,38 @@
 #define WRITEDATA		0x40 // 
 
 
+
+#define SSD1306_SEND_COMMAND(c, d) i2c_smbus_write_byte_data((c), 0x00, (d))
+
+#define SET_LOW_COLUMN			0x00
+#define SET_HIGH_COLUMN			0x10
+#define COLUMN_ADDR				0x21
+#define PAGE_ADDR				0x22
+#define SET_START_PAGE			0xB0
+#define CHARGE_PUMP				0x8D
+#define DISPLAY_OFF				0xAE
+#define DISPLAY_ON				0xAF
+
+#define MEMORY_MODE				0x20
+#define SET_CONTRAST			0x81
+#define SET_NORMAL_DISPLAY		0xA6
+#define SET_INVERT_DISPLAY		0xA7
+#define COM_SCAN_INC			0xC0
+#define COM_SCAN_DEC			0xC8
+#define SET_DISPLAY_OFFSET		0xD3
+#define SET_DISPLAY_CLOCK_DIV	0xD5
+#define SET_PRECHARGE			0xD9
+#define SET_COM_PINS			0xDA
+#define SET_VCOM_DETECT			0xDB
+
+/* Memory modes */
+enum {
+	SSD1306_MEM_MODE_HORIZONAL = 0,
+	SSD1306_MEM_MODE_VERTICAL,
+	SSD1306_MEM_MODE_PAGE,
+	SSD1306_MEM_MODE_INVALID
+};
+
 static struct device *dev;
 
 
@@ -55,8 +87,17 @@ static struct fb_var_screeninfo ssd1307fb_var = {
 };
 
 
+typedef struct ssd1306_data_array
+{
+	u8      type;
+    u8      data[LCD_WIDTH * LCD_HEIGHT / 8];
+
+} ssd1306_data_array;
+
+ssd1306_data_array dataArray;
+
 /* SSD1306 data buffer */
-static u8 ssd1306_Buffer[LCD_WIDTH * LCD_HEIGHT / 8];
+u8 *ssd1306_Buffer = &dataArray.data[0];
 static u8 *lcd_vmem;
 
 
@@ -72,66 +113,69 @@ static void ssd1306_init_lcd(struct i2c_client *drv_client) {
 
     dev_info(dev, "ssd1306: Device init \n");
     /* Init LCD */    
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xAE); //display off
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x20); //Set Memory Addressing Mode
-	i2c_smbus_write_byte_data(drv_client, 0x00, 0x02); //00,Horizontal Addressing Mode;01,Vertical Addressing Mode;10,Page Addressing Mode (RESET);11,Invalid
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xB0); //Set Page Start Address for Page Addressing Mode,0-7
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xC8); //Set COM Output Scan Direction
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x00); //---set low column address
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x10); //---set high column address
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x40); //--set start line address
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x81); //--set contrast control register
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x0A);
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xA1); //--set segment re-map 0 to 127
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xA6); //--set normal display
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xA8); //--set multiplex ratio(1 to 64)
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x3F); //
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xA4); //0xa4,Output follows RAM content;0xa5,Output ignores RAM content
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xD3); //-set display offset
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x00); //-not offset
+	SSD1306_SEND_COMMAND(drv_client, DISPLAY_OFF);
 
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xD5); //--set display clock divide ratio/oscillator frequency
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xa0); //--set divide ratio
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xD9); //--set pre-charge period
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x22); //
+	SSD1306_SEND_COMMAND(drv_client, MEMORY_MODE);
+	SSD1306_SEND_COMMAND(drv_client, SSD1306_MEM_MODE_HORIZONAL);
+	/* Set column start / end */
+	SSD1306_SEND_COMMAND(drv_client, COLUMN_ADDR);
+	SSD1306_SEND_COMMAND(drv_client, 0);
+	SSD1306_SEND_COMMAND(drv_client, (LCD_WIDTH - 1));
 
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xDA); //--set com pins hardware configuration
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x12);
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xDB); //--set vcomh
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x20); //0x20,0.77xVcc
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x8D); //--set DC-DC enable
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0x14); //
-    i2c_smbus_write_byte_data(drv_client, 0x00, 0xAF); //--turn on SSD1306 panel
+	/* Set page start / end */
+	SSD1306_SEND_COMMAND(drv_client, PAGE_ADDR);
+	SSD1306_SEND_COMMAND(drv_client, 0);
+	SSD1306_SEND_COMMAND(drv_client, (LCD_HEIGHT / 8 - 1));
+
+	SSD1306_SEND_COMMAND(drv_client, COM_SCAN_DEC);
+
+	SSD1306_SEND_COMMAND(drv_client, SET_CONTRAST);
+	SSD1306_SEND_COMMAND(drv_client, 0xFF); /* Max contrast */
+
+	SSD1306_SEND_COMMAND(drv_client, 0xA1); /* set segment re-map 0 to 127 */
+	SSD1306_SEND_COMMAND(drv_client, SET_NORMAL_DISPLAY);
+	SSD1306_SEND_COMMAND(drv_client, 0xA8); /* set multiplex ratio(1 to 64) */
+	SSD1306_SEND_COMMAND(drv_client, (LCD_HEIGHT - 1));
+	SSD1306_SEND_COMMAND(drv_client, 0xA4); /* 0xA4 => follows RAM content */
+	SSD1306_SEND_COMMAND(drv_client, SET_DISPLAY_OFFSET);
+	SSD1306_SEND_COMMAND(drv_client, 0x00); /* no offset */
+
+	SSD1306_SEND_COMMAND(drv_client, SET_DISPLAY_CLOCK_DIV);
+	SSD1306_SEND_COMMAND(drv_client, 0x80); /* set divide ratio */
+
+	SSD1306_SEND_COMMAND(drv_client, SET_PRECHARGE);
+	SSD1306_SEND_COMMAND(drv_client, 0x22);
+
+	SSD1306_SEND_COMMAND(drv_client, SET_COM_PINS);
+	SSD1306_SEND_COMMAND(drv_client, 0x12);
+
+	SSD1306_SEND_COMMAND(drv_client, SET_VCOM_DETECT);
+	SSD1306_SEND_COMMAND(drv_client, 0x20); /* 0x20, 0.77x Vcc */
     
-    for (m = 0; m < 8; m++) {
-        i2c_smbus_write_byte_data(drv_client, 0x00, 0xB0 + m);
-        i2c_smbus_write_byte_data(drv_client, 0x00, 0x00);
-        i2c_smbus_write_byte_data(drv_client, 0x00, 0x10);
-        // Write multi data 
-        
-        for (i = 0; i < LCD_WIDTH; i++) {
-            i2c_smbus_write_byte_data(drv_client, 0x40, 0xaa);
-        }        
-    }   
+
+	SSD1306_SEND_COMMAND(drv_client, 0x8D);
+	SSD1306_SEND_COMMAND(drv_client, 0x14);
+	SSD1306_SEND_COMMAND(drv_client, 0xAF);
 }
+
+
 
 int ssd1306_UpdateScreen(struct ssd1306_data *drv_data) {
 
     struct i2c_client *drv_client;
     char m;
     char i;
+	int ret;
 
     drv_client = drv_data->client;
-
-    for (m = 0; m < 8; m++) {
-        i2c_smbus_write_byte_data(drv_client, 0x00, 0xB0 + m);
-        i2c_smbus_write_byte_data(drv_client, 0x00, 0x00);
-        i2c_smbus_write_byte_data(drv_client, 0x00, 0x10);
-        /* Write multi data */
-		for (i = 0; i < drv_data->width; i++) {
-			i2c_smbus_write_byte_data(drv_client, 0x40, ssd1306_Buffer[drv_data->width*m +i]);
-        }   
-    }
+    
+    dataArray.type = 0x40;
+	ret = i2c_master_send(drv_client, (u8 *) &dataArray, sizeof(ssd1306_data_array));
+	if (unlikely(ret < 0))
+	{
+		printk(KERN_ERR "i2c_master_send() has returned ERROR %d\n", ret);
+		return ret;
+	}    
 
     return 0;
 }
@@ -226,12 +270,6 @@ static int ssd1307fb_blank(int blank_mode, struct fb_info *info)
 {
     struct ssd1306_data *lcd = info->par;
 
-/*
-	if (blank_mode != FB_BLANK_UNBLANK)
-		return ssd1307fb_write_cmd(lcd->client, SSD1307FB_DISPLAY_OFF);
-	else
-		return ssd1307fb_write_cmd(lcd->client, SSD1307FB_DISPLAY_ON);
-*/
     if (blank_mode != FB_BLANK_UNBLANK)
     	return ssd1306_OFF(lcd);
     else
@@ -319,13 +357,9 @@ static int ssd1306_probe(struct i2c_client *drv_client,
 	lcd->height = LCD_HEIGHT;
 
 	vmem_size = lcd->width * lcd->height / 8;
-
 	
     lcd_vmem = devm_kzalloc(&drv_client->dev, vmem_size, GFP_KERNEL);
-
-/*	lcd_vmem = (void *)__get_free_pages(GFP_KERNEL | __GFP_ZERO,
-					get_order(vmem_size));
-*/	
+	
     if (!lcd_vmem) {
 		dev_err(dev, "Couldn't allocate graphical memory.\n");
 		return -ENOMEM;        

--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -1,0 +1,117 @@
+/*
+ * Texas Instruments TMP103 SMBus temperature sensor driver
+ * Copyright (C) 2014 Heiko Schocher <hs@denx.de>
+ *
+ * Based on:
+ * Texas Instruments TMP102 SMBus temperature sensor driver
+ *
+ * Copyright (C) 2010 Steven King <sfking@fdwdc.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/input.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/err.h>
+
+
+#define DEVICE_NAME	"lcd_ssd1306"
+#define CLASS_NAME	"oled_display" 
+#define BUS_NAME	"i2c_1"
+
+#define SSD1306_WIDTH	128
+#define SSD1306_HEIGHT	64
+
+
+static struct device *dev;
+
+
+
+
+static int ssd1306_probe(struct i2c_client *drv_client,
+			const struct i2c_device_id *id)
+{
+	struct i2c_adapter *adapter;
+
+	dev = &drv_client->dev;
+
+	dev_info(dev, "init I2C driver\n");
+
+
+    adapter = drv_client->adapter;
+
+    if (!adapter)
+    {
+        dev_err(dev, "adapter indentification error\n");
+        return -ENODEV;
+    }
+
+    dev_info(dev, "I2C client address %d \n", drv_client->addr);
+
+    if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+            dev_err(dev, "operation not supported\n");
+            return -ENODEV;
+    }
+
+
+
+    dev_info(dev, "ssd1306 driver successfully loaded\n");
+
+	return 0;
+}
+
+
+
+static int ssd1306_remove(struct i2c_client *client)
+{
+	struct class *sys_class;
+
+	dev_info(dev, "Goodbye, world!\n");
+	return 0;
+}
+
+
+
+static const struct of_device_id ssd1306_match[] = {
+	{ .compatible = "DAndy,lcd_ssd1306", },
+	{ },
+};
+MODULE_DEVICE_TABLE(of, ssd1306_match);
+
+static const struct i2c_device_id ssd1306_id[] = {
+	{ "lcd_ssd1306", 0 },
+	{ }
+};
+MODULE_DEVICE_TABLE(i2c, ssd1306_id);
+
+
+static struct i2c_driver ssd1306_driver = {
+	.driver = {
+		.name	= DEVICE_NAME,
+		.of_match_table = ssd1306_match,
+	},
+	.probe		= ssd1306_probe,
+	.remove 	= ssd1306_remove,
+	.id_table	= ssd1306_id,
+};
+module_i2c_driver(ssd1306_driver);
+
+MODULE_AUTHOR("Devyatov Andrey <andrii.deviatov@globallogic.com>");
+MODULE_DESCRIPTION("ssd1306 I2C");
+MODULE_LICENSE("GPL");

--- a/userapp_analog_clock/Makefile
+++ b/userapp_analog_clock/Makefile
@@ -1,0 +1,10 @@
+
+
+
+
+all:
+	$(CROSS_COMPILE)gcc -Wall -o analog_clock analog_clock.c
+
+clean:
+	rm fb_user
+

--- a/userapp_analog_clock/Makefile
+++ b/userapp_analog_clock/Makefile
@@ -1,10 +1,14 @@
 
+CROSS_COMPILE ?= arm-linux-gnueabihf-
+CC = $(CROSS_COMPILE)gcc
+CFLAGS = -Wall
 
+.PHONY: all clean
 
+all: analog_clock
 
-all:
-	$(CROSS_COMPILE)gcc -Wall -o analog_clock analog_clock.c
+analog_clock: analog_clock.c
+	$(CC) $(CFLAGS) $^ -o $@
 
 clean:
-	rm fb_user
-
+	rm analog_clock

--- a/userapp_analog_clock/README.md
+++ b/userapp_analog_clock/README.md
@@ -1,0 +1,3 @@
+## userapp_analog_clock
+A Linux userspace application. Draws a simple analog clock on fb0 FrameBuffer device.
+[Low-Level Graphics on Linux](http://betteros.org/tut/graphics1.php)

--- a/userapp_analog_clock/analog_clock.c
+++ b/userapp_analog_clock/analog_clock.c
@@ -1,0 +1,387 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <linux/fb.h>
+#include <linux/kd.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <string.h>
+
+#include <math.h>
+#include <unistd.h>
+
+typedef unsigned char 	u8;
+typedef unsigned short 	u16;
+
+#define SSD1306_WIDTH	128
+#define SSD1306_HEIGHT	64
+
+
+
+typedef struct{
+	u16 	X;
+	u16 	Y;
+}_Point;
+
+typedef enum {
+		SSD1306_COLOR_BLACK = 0x00,   /*!< Black color, no pixel */
+		SSD1306_COLOR_WHITE = 0x01    /*!< Pixel is set. Color depends on LCD */
+} ssd1306_COLOR_t;
+
+
+typedef struct {
+	struct fb_var_screeninfo vinfo;
+	struct fb_fix_screeninfo finfo;
+	int width;
+	int height;
+	long int screensize;
+	char *fbp;
+
+}lcd_type;
+
+static lcd_type lcd;
+
+
+static u8 ssd1306_Buffer[SSD1306_WIDTH * SSD1306_HEIGHT / 8];
+
+
+
+static int ssd1306_DrawPixel(u16 x, u16 y, ssd1306_COLOR_t color) {
+
+	if ( x > SSD1306_WIDTH || y > SSD1306_HEIGHT ) {
+		return -1;
+	}
+
+	/* Set color */
+	if (color == SSD1306_COLOR_WHITE) {
+		ssd1306_Buffer[x/8 + (y * (SSD1306_WIDTH / 8))] |= (1 << (x % 8));
+	}
+	else {
+		ssd1306_Buffer[x/8 + (y * (SSD1306_WIDTH / 8))] &= ~(1 << (x % 8));
+	}
+
+	return 0;
+}
+
+
+
+static void Graphic_setPoint(const u16 X, const u16 Y)
+{
+	ssd1306_DrawPixel(X, Y, SSD1306_COLOR_WHITE);
+}
+
+
+
+static void Graphic_drawLine(_Point p1, _Point p2){
+	int dx, dy, inx, iny, e;
+	u16 x1 = p1.X, x2 = p2.X;
+	u16 y1 = p1.Y, y2 = p2.Y;
+
+	dx = x2 - x1;
+	dy = y2 - y1;
+	inx = dx > 0 ? 1 : -1;
+	iny = dy > 0 ? 1 : -1;
+
+	dx = (dx > 0) ? dx : -dx;
+	dy = (dy > 0) ? dy : -dy;
+
+
+	if(dx >= dy) {
+		dy <<= 1;
+		e = dy - dx;
+		dx <<= 1;
+		while (x1 != x2){
+			Graphic_setPoint(x1, y1);
+			if(e >= 0){
+				y1 += iny;
+				e-= dx;
+			}
+			e += dy;
+			x1 += inx;
+		}
+	}
+	else{
+		dx <<= 1;
+		e = dx - dy;
+		dy <<= 1;
+		while (y1 != y2){
+			Graphic_setPoint(x1, y1);
+			if(e >= 0){
+				x1 += inx;
+				e -= dy;
+			}
+			e += dx;
+			y1 += iny;
+		}	}
+	Graphic_setPoint(x1, y1);
+}
+// ---------------------------------------------------------------------------
+
+
+static void Graphic_drawLine_(u16 x1, u16 y1, u16 x2, u16 y2){
+	_Point p1 = {0}, p2 = {0};
+	p1.X = x1;
+	p1.Y = y1;
+	p2.X = x2;
+	p2.Y = y2;
+
+	Graphic_drawLine(p1, p2);
+}
+// ---------------------------------------------------------------------------
+
+
+
+void Graphic_drawCircle(_Point center, u16 r){
+	int  draw_x0, draw_y0;			//draw points
+	int  draw_x1, draw_y1;
+	int  draw_x2, draw_y5;
+	int  draw_x3, draw_y3;
+	int  draw_x4, draw_y4;
+	int  draw_x6, draw_y6;
+	int  draw_x7, draw_y7;
+	int  draw_x5, draw_y2;
+	int  xx, yy;					// circle control variable
+	int  di;						// decide variable
+	
+	if( 0 == r)
+		return;
+
+	// calculate 8 special point(0��45��90��135��180��225��270degree) display them 
+	draw_x0 = draw_x1 = center.X;
+	draw_y0 = draw_y1 = center.Y + r;
+	if(draw_y0<63)
+		Graphic_setPoint(draw_x0, draw_y0);	// 90degree
+	draw_x2 = draw_x3 = center.X;
+	draw_y2 = draw_y3 = center.Y - r;
+	if(draw_y2>=0)
+		Graphic_setPoint(draw_x2,draw_y2);// 270degree
+	draw_x4 = draw_x6 = center.X + r;
+	draw_y4 = draw_y6 = center.Y;
+	if(draw_x4<127)
+		Graphic_setPoint(draw_x4, draw_y4);// 0degree
+	draw_x5 = draw_x7 = center.X - r;
+	draw_y5 = draw_y7 = center.Y;
+	if(draw_x5>=0)
+		Graphic_setPoint(draw_x5, draw_y5);	// 180degree
+	if(1==r)   // if the radius is 1, finished.
+		return;
+	//using Bresenham 
+	di = 3 - 2*r;
+	xx = 0;
+	yy = r;
+	while(xx<yy){
+		if(di<0){
+			di += 4*xx + 6;
+		}else{
+			di += 4*(xx - yy) + 10;
+			yy--;
+			draw_y0--;
+			draw_y1--;
+			draw_y2++;
+			draw_y3++;
+			draw_x4--;
+			draw_x5++;
+			draw_x6--;
+			draw_x7++;
+		}
+		xx++;
+		draw_x0++;
+		draw_x1--;
+		draw_x2++;
+		draw_x3--;
+		draw_y4++;
+		draw_y5++;
+		draw_y6--;
+		draw_y7--;
+		//judge current point in the avaible range
+		if( (draw_x0<=127)&&(draw_y0>=0) ){
+			Graphic_setPoint(draw_x0, draw_y0);
+		}	
+		if( (draw_x1>=0)&&(draw_y1>=0) ){
+			Graphic_setPoint(draw_x1, draw_y1);
+		}
+		if( (draw_x2<=127)&&(draw_y2<=63) ){
+			Graphic_setPoint(draw_x2, draw_y2);
+		}
+		if( (draw_x3>=0)&&(draw_y3<=63) ){ 
+			Graphic_setPoint(draw_x3, draw_y3);
+		}
+		if( (draw_x4<=127)&&(draw_y4>=0) ){
+			Graphic_setPoint(draw_x4, draw_y4);
+		}
+		if( (draw_x5>=0)&&(draw_y5>=0) ){
+			Graphic_setPoint(draw_x5, draw_y5);
+		}
+		if( (draw_x6<=127)&&(draw_y6<=63) ){
+			Graphic_setPoint(draw_x6, draw_y6);
+		}
+		if( (draw_x7>=0)&&(draw_y7<=63) ){ 
+			Graphic_setPoint(draw_x7, draw_y7);
+		}
+	}
+}
+
+
+static void Graphic_ClearScreen(void){
+	memset(ssd1306_Buffer, 0, sizeof(ssd1306_Buffer));
+}
+
+
+static void Graphic_UpdateScreen(void){
+
+	int i = 0;
+
+	for (i=0; i < lcd.screensize; i++) {
+
+		*(lcd.fbp+i) = ssd1306_Buffer[i];
+
+	}
+}
+
+
+
+int fb;
+struct fb_var_screeninfo fb_var;
+struct fb_var_screeninfo fb_screen;
+struct fb_fix_screeninfo fb_fix;
+unsigned char *fb_mem = NULL;
+unsigned char *fb_screenMem = NULL;
+
+
+
+#ifndef PAGE_SHIFT
+	#define PAGE_SHIFT 12
+#endif
+#ifndef PAGE_SIZE
+	#define PAGE_SIZE (1UL << PAGE_SHIFT)
+#endif
+#ifndef PAGE_MASK
+	#define PAGE_MASK (~(PAGE_SIZE - 1))
+#endif
+
+int fb_init(char *device) {
+
+	int fb_mem_offset;
+
+	// get current settings (which we have to restore)
+	if (-1 == (fb = open(device, O_RDWR))) {
+		fprintf(stderr, "Open %s error\n", device);
+		return 0;
+	}
+	if (-1 == ioctl(fb, FBIOGET_VSCREENINFO, &fb_var)) {
+		fprintf(stderr, "Ioctl FBIOGET_VSCREENINFO error.\n");
+		return 0;
+	}
+	if (-1 == ioctl(fb, FBIOGET_FSCREENINFO, &fb_fix)) {
+		fprintf(stderr, "Ioctl FBIOGET_FSCREENINFO error.\n");
+		return 0;
+	}
+	if (fb_fix.type != FB_TYPE_PACKED_PIXELS) {
+		fprintf(stderr, "Can handle only packed pixel frame buffers.\n");
+		goto err;
+	}
+
+	fb_mem_offset = (unsigned long)(fb_fix.smem_start) & (~PAGE_MASK);
+	fb_mem = mmap(NULL, fb_fix.smem_len + fb_mem_offset, PROT_READ | PROT_WRITE, MAP_SHARED, fb, 0);
+	if (-1L == (long)fb_mem) {
+		fprintf(stderr, "Mmap error.\n");
+		goto err;
+	}
+	// move viewport to upper left corner
+	if (fb_var.xoffset != 0 || fb_var.yoffset != 0) {
+		fb_var.xoffset = 0;
+		fb_var.yoffset = 0;
+		if (-1 == ioctl(fb, FBIOPAN_DISPLAY, &fb_var)) {
+			fprintf(stderr, "Ioctl FBIOPAN_DISPLAY error.\n");
+			munmap(fb_mem, fb_fix.smem_len);
+			goto err;
+		}
+	}
+ 
+
+	lcd.width 		= fb_var.xres;
+	lcd.height 		= fb_var.yres;
+	lcd.screensize 	= fb_var.xres * fb_var.yres * fb_var.bits_per_pixel / 8;
+	lcd.fbp 		= fb_mem;
+
+	printf("lcd.width %d\n", lcd.width);
+	printf("lcd.height %d\n", lcd.height);
+
+	return 1;
+
+err:
+	if (-1 == ioctl(fb, FBIOPUT_VSCREENINFO, &fb_var))
+		fprintf(stderr, "Ioctl FBIOPUT_VSCREENINFO error.\n");
+	if (-1 == ioctl(fb, FBIOGET_FSCREENINFO, &fb_fix))
+		fprintf(stderr, "Ioctl FBIOGET_FSCREENINFO.\n");
+	return 0;
+}
+
+void fb_cleanup(void) {
+
+	if (-1 == ioctl(fb, FBIOPUT_VSCREENINFO, &fb_var))
+		fprintf(stderr, "Ioctl FBIOPUT_VSCREENINFO error.\n");
+	if (-1 == ioctl(fb, FBIOGET_FSCREENINFO, &fb_fix))
+		fprintf(stderr, "Ioctl FBIOGET_FSCREENINFO.\n");
+	munmap(fb_mem, fb_fix.smem_len);
+	close(fb);
+}
+
+
+int main(int argc, char **argv)
+{	
+	int x = 0, y = 0, i = 0;
+	long int location = 0;
+	
+	_Point center;
+	int radius = 0;
+	float angle = 0.0;
+	float angle2 = 0.0;
+
+	if (!fb_init("/dev/fb0"))
+		exit(1);
+
+
+
+
+	Graphic_ClearScreen();
+
+	center.X 	= lcd.width / 2;
+	center.Y 	= lcd.height / 2;
+	radius 		= 31;
+	Graphic_drawCircle(center, radius);
+
+	angle = 0.0;
+
+	//for(angle = 0.0; angle <= 360; ){
+	for(angle = 0.0; ; ){
+
+		Graphic_ClearScreen();
+		Graphic_drawCircle(center, radius);
+
+		for(angle2 = 0.0; angle2 <= 360; ){
+			Graphic_drawLine_(
+				center.X + (radius -4) * cos((M_PI/180.0)*angle2 - M_PI/2),
+				center.Y + (radius -4) * sin((M_PI/180.0)*angle2 - M_PI/2),
+
+				center.X + radius * cos((M_PI/180.0)*angle2 - M_PI/2),
+				center.Y + radius * sin((M_PI/180.0)*angle2 - M_PI/2));
+				
+				angle2 += 90.0;
+		}
+
+		Graphic_drawLine_(center.X, center.Y, 
+				center.X + (radius -4) * cos((M_PI/180.0)*angle - M_PI/2),
+				center.Y + (radius -4) * sin((M_PI/180.0)*angle - M_PI/2));
+		angle += 6.0;
+		Graphic_UpdateScreen();
+		sleep(1);
+	}
+
+	Graphic_UpdateScreen();
+		  
+
+	fb_cleanup();
+	return(0);
+}

--- a/userapp_analog_clock/analog_clock.c
+++ b/userapp_analog_clock/analog_clock.c
@@ -270,7 +270,7 @@ int fb_init(char *device)
 
 	/* get current settings (which we have to restore) */
 	fb = open(device, O_RDWR);
-	if (fb == -1 {
+	if (fb == -1){
 		fprintf(stderr, "Open %s error\n", device);
 		return 0;
 	}

--- a/userapp_analog_clock/analog_clock.c
+++ b/userapp_analog_clock/analog_clock.c
@@ -11,8 +11,8 @@
 #include <math.h>
 #include <unistd.h>
 
-typedef unsigned char 	u8;
-typedef unsigned short 	u16;
+typedef unsigned char	u8;
+typedef unsigned short	u16;
 
 #define SSD1306_WIDTH	128
 #define SSD1306_HEIGHT	64
@@ -20,13 +20,13 @@ typedef unsigned short 	u16;
 
 
 typedef struct{
-	u16 	X;
-	u16 	Y;
-}_Point;
+	u16	X;
+	u16	Y;
+} _Point;
 
 typedef enum {
-		SSD1306_COLOR_BLACK = 0x00,   /*!< Black color, no pixel */
-		SSD1306_COLOR_WHITE = 0x01    /*!< Pixel is set. Color depends on LCD */
+		SSD1306_COLOR_BLACK = 0x00, /*!< Black color, no pixel */
+		SSD1306_COLOR_WHITE = 0x01  /*!< Pixel is set */
 } ssd1306_COLOR_t;
 
 
@@ -38,7 +38,7 @@ typedef struct {
 	long int screensize;
 	char *fbp;
 
-}lcd_type;
+} lcd_type;
 
 static lcd_type lcd;
 
@@ -47,19 +47,17 @@ static u8 ssd1306_Buffer[SSD1306_WIDTH * SSD1306_HEIGHT / 8];
 
 
 
-static int ssd1306_DrawPixel(u16 x, u16 y, ssd1306_COLOR_t color) {
+static int ssd1306_DrawPixel(u16 x, u16 y, ssd1306_COLOR_t color)
+{
 
-	if ( x > SSD1306_WIDTH || y > SSD1306_HEIGHT ) {
+	if (x > SSD1306_WIDTH || y > SSD1306_HEIGHT)
 		return -1;
-	}
 
 	/* Set color */
-	if (color == SSD1306_COLOR_WHITE) {
+	if (color == SSD1306_COLOR_WHITE)
 		ssd1306_Buffer[x/8 + (y * (SSD1306_WIDTH / 8))] |= (1 << (x % 8));
-	}
-	else {
+	else
 		ssd1306_Buffer[x/8 + (y * (SSD1306_WIDTH / 8))] &= ~(1 << (x % 8));
-	}
 
 	return 0;
 }
@@ -73,7 +71,8 @@ static void Graphic_setPoint(const u16 X, const u16 Y)
 
 
 
-static void Graphic_drawLine(_Point p1, _Point p2){
+static void Graphic_drawLine(_Point p1, _Point p2)
+{
 	int dx, dy, inx, iny, e;
 	u16 x1 = p1.X, x2 = p2.X;
 	u16 y1 = p1.Y, y2 = p2.Y;
@@ -87,40 +86,42 @@ static void Graphic_drawLine(_Point p1, _Point p2){
 	dy = (dy > 0) ? dy : -dy;
 
 
-	if(dx >= dy) {
+	if (dx >= dy) {
 		dy <<= 1;
 		e = dy - dx;
 		dx <<= 1;
-		while (x1 != x2){
+		while (x1 != x2) {
 			Graphic_setPoint(x1, y1);
-			if(e >= 0){
+			if (e >= 0) {
 				y1 += iny;
-				e-= dx;
+				e -= dx;
 			}
 			e += dy;
 			x1 += inx;
 		}
-	}
-	else{
+	} else {
 		dx <<= 1;
 		e = dx - dy;
 		dy <<= 1;
-		while (y1 != y2){
+		while (y1 != y2) {
 			Graphic_setPoint(x1, y1);
-			if(e >= 0){
+			if (e >= 0) {
 				x1 += inx;
 				e -= dy;
 			}
 			e += dx;
 			y1 += iny;
-		}	}
+		}
+	}
 	Graphic_setPoint(x1, y1);
 }
-// ---------------------------------------------------------------------------
 
 
-static void Graphic_drawLine_(u16 x1, u16 y1, u16 x2, u16 y2){
+
+static void Graphic_drawLine_(u16 x1, u16 y1, u16 x2, u16 y2)
+{
 	_Point p1 = {0}, p2 = {0};
+
 	p1.X = x1;
 	p1.Y = y1;
 	p2.X = x2;
@@ -128,12 +129,12 @@ static void Graphic_drawLine_(u16 x1, u16 y1, u16 x2, u16 y2){
 
 	Graphic_drawLine(p1, p2);
 }
-// ---------------------------------------------------------------------------
 
 
 
-void Graphic_drawCircle(_Point center, u16 r){
-	int  draw_x0, draw_y0;			//draw points
+void Graphic_drawCircle(_Point center, u16 r)
+{
+	int  draw_x0, draw_y0; /* draw points */
 	int  draw_x1, draw_y1;
 	int  draw_x2, draw_y5;
 	int  draw_x3, draw_y3;
@@ -141,39 +142,45 @@ void Graphic_drawCircle(_Point center, u16 r){
 	int  draw_x6, draw_y6;
 	int  draw_x7, draw_y7;
 	int  draw_x5, draw_y2;
-	int  xx, yy;					// circle control variable
-	int  di;						// decide variable
-	
-	if( 0 == r)
+	int  xx, yy; /* circle control variable */
+	int  di; /* decide variable */
+
+	if (r == 0)
 		return;
 
-	// calculate 8 special point(0��45��90��135��180��225��270degree) display them 
 	draw_x0 = draw_x1 = center.X;
 	draw_y0 = draw_y1 = center.Y + r;
-	if(draw_y0<63)
-		Graphic_setPoint(draw_x0, draw_y0);	// 90degree
+	if (draw_y0 < 63)
+		Graphic_setPoint(draw_x0, draw_y0);	/* 90 degree */
+
 	draw_x2 = draw_x3 = center.X;
 	draw_y2 = draw_y3 = center.Y - r;
-	if(draw_y2>=0)
-		Graphic_setPoint(draw_x2,draw_y2);// 270degree
+
+	if (draw_y2 >= 0)
+		Graphic_setPoint(draw_x2, draw_y2); /* 270 degree */
+
 	draw_x4 = draw_x6 = center.X + r;
 	draw_y4 = draw_y6 = center.Y;
-	if(draw_x4<127)
-		Graphic_setPoint(draw_x4, draw_y4);// 0degree
+
+	if (draw_x4 < 127)
+		Graphic_setPoint(draw_x4, draw_y4); /* 0 degree */
+
 	draw_x5 = draw_x7 = center.X - r;
 	draw_y5 = draw_y7 = center.Y;
-	if(draw_x5>=0)
-		Graphic_setPoint(draw_x5, draw_y5);	// 180degree
-	if(1==r)   // if the radius is 1, finished.
+
+	if (draw_x5 >= 0)
+		Graphic_setPoint(draw_x5, draw_y5);	/* 180degree */
+
+	if (r == 1)   /* if the radius is 1, finished.*/
 		return;
-	//using Bresenham 
+	/* using Bresenham */
 	di = 3 - 2*r;
 	xx = 0;
 	yy = r;
-	while(xx<yy){
-		if(di<0){
+	while (xx < yy) {
+		if (di < 0) {
 			di += 4*xx + 6;
-		}else{
+		} else{
 			di += 4*(xx - yy) + 10;
 			yy--;
 			draw_y0--;
@@ -194,49 +201,46 @@ void Graphic_drawCircle(_Point center, u16 r){
 		draw_y5++;
 		draw_y6--;
 		draw_y7--;
-		//judge current point in the avaible range
-		if( (draw_x0<=127)&&(draw_y0>=0) ){
+		/* judge current point in the avaible range */
+		if ((draw_x0 <= 127) && (draw_y0 >= 0))
 			Graphic_setPoint(draw_x0, draw_y0);
-		}	
-		if( (draw_x1>=0)&&(draw_y1>=0) ){
+
+		if ((draw_x1 >= 0) && (draw_y1 >= 0))
 			Graphic_setPoint(draw_x1, draw_y1);
-		}
-		if( (draw_x2<=127)&&(draw_y2<=63) ){
+
+		if ((draw_x2 <= 127) && (draw_y2 <= 63))
 			Graphic_setPoint(draw_x2, draw_y2);
-		}
-		if( (draw_x3>=0)&&(draw_y3<=63) ){ 
+
+		if ((draw_x3 >= 0) && (draw_y3 <= 63))
 			Graphic_setPoint(draw_x3, draw_y3);
-		}
-		if( (draw_x4<=127)&&(draw_y4>=0) ){
+
+		if ((draw_x4 <= 127) && (draw_y4 >= 0))
 			Graphic_setPoint(draw_x4, draw_y4);
-		}
-		if( (draw_x5>=0)&&(draw_y5>=0) ){
+
+		if ((draw_x5 >= 0) && (draw_y5 >= 0))
 			Graphic_setPoint(draw_x5, draw_y5);
-		}
-		if( (draw_x6<=127)&&(draw_y6<=63) ){
+
+		if ((draw_x6 <= 127) && (draw_y6 <= 63))
 			Graphic_setPoint(draw_x6, draw_y6);
-		}
-		if( (draw_x7>=0)&&(draw_y7<=63) ){ 
+
+		if ((draw_x7 >= 0) && (draw_y7 <= 63))
 			Graphic_setPoint(draw_x7, draw_y7);
-		}
 	}
 }
 
 
-static void Graphic_ClearScreen(void){
+static void Graphic_ClearScreen(void)
+{
 	memset(ssd1306_Buffer, 0, sizeof(ssd1306_Buffer));
 }
 
 
-static void Graphic_UpdateScreen(void){
-
+static void Graphic_UpdateScreen(void)
+{
 	int i = 0;
 
-	for (i=0; i < lcd.screensize; i++) {
-
+	for (i = 0; i < lcd.screensize; i++)
 		*(lcd.fbp+i) = ssd1306_Buffer[i];
-
-	}
 }
 
 
@@ -245,8 +249,8 @@ int fb;
 struct fb_var_screeninfo fb_var;
 struct fb_var_screeninfo fb_screen;
 struct fb_fix_screeninfo fb_fix;
-unsigned char *fb_mem = NULL;
-unsigned char *fb_screenMem = NULL;
+unsigned char *fb_mem;
+unsigned char *fb_screenMem;
 
 
 
@@ -260,12 +264,13 @@ unsigned char *fb_screenMem = NULL;
 	#define PAGE_MASK (~(PAGE_SIZE - 1))
 #endif
 
-int fb_init(char *device) {
-
+int fb_init(char *device)
+{
 	int fb_mem_offset;
 
-	// get current settings (which we have to restore)
-	if (-1 == (fb = open(device, O_RDWR))) {
+	/* get current settings (which we have to restore) */
+	fb = open(device, O_RDWR);
+	if (fb == -1 {
 		fprintf(stderr, "Open %s error\n", device);
 		return 0;
 	}
@@ -283,12 +288,15 @@ int fb_init(char *device) {
 	}
 
 	fb_mem_offset = (unsigned long)(fb_fix.smem_start) & (~PAGE_MASK);
-	fb_mem = mmap(NULL, fb_fix.smem_len + fb_mem_offset, PROT_READ | PROT_WRITE, MAP_SHARED, fb, 0);
+	fb_mem = mmap(NULL, fb_fix.smem_len + fb_mem_offset, PROT_READ
+			| PROT_WRITE, MAP_SHARED, fb, 0);
+
 	if (-1L == (long)fb_mem) {
 		fprintf(stderr, "Mmap error.\n");
 		goto err;
 	}
-	// move viewport to upper left corner
+
+	/* move viewport to upper left corner */
 	if (fb_var.xoffset != 0 || fb_var.yoffset != 0) {
 		fb_var.xoffset = 0;
 		fb_var.yoffset = 0;
@@ -298,12 +306,12 @@ int fb_init(char *device) {
 			goto err;
 		}
 	}
- 
 
-	lcd.width 		= fb_var.xres;
-	lcd.height 		= fb_var.yres;
-	lcd.screensize 	= fb_var.xres * fb_var.yres * fb_var.bits_per_pixel / 8;
-	lcd.fbp 		= fb_mem;
+
+	lcd.width		= fb_var.xres;
+	lcd.height		= fb_var.yres;
+	lcd.screensize	= fb_var.xres * fb_var.yres * fb_var.bits_per_pixel / 8;
+	lcd.fbp			= fb_mem;
 
 	printf("lcd.width %d\n", lcd.width);
 	printf("lcd.height %d\n", lcd.height);
@@ -318,7 +326,8 @@ err:
 	return 0;
 }
 
-void fb_cleanup(void) {
+void fb_cleanup(void)
+{
 
 	if (-1 == ioctl(fb, FBIOPUT_VSCREENINFO, &fb_var))
 		fprintf(stderr, "Ioctl FBIOPUT_VSCREENINFO error.\n");
@@ -330,10 +339,10 @@ void fb_cleanup(void) {
 
 
 int main(int argc, char **argv)
-{	
+{
 	int x = 0, y = 0, i = 0;
 	long int location = 0;
-	
+
 	_Point center;
 	int radius = 0;
 	float angle = 0.0;
@@ -347,41 +356,39 @@ int main(int argc, char **argv)
 
 	Graphic_ClearScreen();
 
-	center.X 	= lcd.width / 2;
-	center.Y 	= lcd.height / 2;
-	radius 		= 31;
+	center.X	= lcd.width / 2;
+	center.Y	= lcd.height / 2;
+	radius		= 31;
 	Graphic_drawCircle(center, radius);
 
 	angle = 0.0;
 
-	//for(angle = 0.0; angle <= 360; ){
-	for(angle = 0.0; ; ){
+	for (angle = 0.0; ;) {
 
 		Graphic_ClearScreen();
 		Graphic_drawCircle(center, radius);
 
-		for(angle2 = 0.0; angle2 <= 360; ){
+		for (angle2 = 0.0; angle2 <= 360;) {
 			Graphic_drawLine_(
-				center.X + (radius -4) * cos((M_PI/180.0)*angle2 - M_PI/2),
-				center.Y + (radius -4) * sin((M_PI/180.0)*angle2 - M_PI/2),
+				center.X + (radius - 4) * cos((M_PI/180.0)*angle2 - M_PI/2),
+				center.Y + (radius - 4) * sin((M_PI/180.0)*angle2 - M_PI/2),
 
 				center.X + radius * cos((M_PI/180.0)*angle2 - M_PI/2),
 				center.Y + radius * sin((M_PI/180.0)*angle2 - M_PI/2));
-				
+
 				angle2 += 90.0;
 		}
 
-		Graphic_drawLine_(center.X, center.Y, 
-				center.X + (radius -4) * cos((M_PI/180.0)*angle - M_PI/2),
-				center.Y + (radius -4) * sin((M_PI/180.0)*angle - M_PI/2));
+		Graphic_drawLine_(center.X, center.Y,
+				center.X + (radius - 4) * cos((M_PI/180.0)*angle - M_PI/2),
+				center.Y + (radius - 4) * sin((M_PI/180.0)*angle - M_PI/2));
 		angle += 6.0;
 		Graphic_UpdateScreen();
 		sleep(1);
 	}
 
 	Graphic_UpdateScreen();
-		  
+
 
 	fb_cleanup();
-	return(0);
 }

--- a/userapp_analog_clock/build_user_app.sh
+++ b/userapp_analog_clock/build_user_app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+export CROSS_COMPILE=${HOME}/BBB/gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux/bin/arm-linux-gnueabihf-
+
+echo ${CROSS_COMPILE}
+
+
+${CROSS_COMPILE}gcc analog_clock.c -o analog_clock -lm
+
+
+echo "Done!"

--- a/userapp_analog_clock/build_user_app.sh
+++ b/userapp_analog_clock/build_user_app.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-export CROSS_COMPILE=${HOME}/BBB/gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux/bin/arm-linux-gnueabihf-
+#export CROSS_COMPILE=${HOME}/BBB/gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux/bin/arm-linux-gnueabihf-
 
-echo ${CROSS_COMPILE}
+echo "CROSS_COMPILE = ${CROSS_COMPILE}"
 
 
 ${CROSS_COMPILE}gcc analog_clock.c -o analog_clock -lm


### PR DESCRIPTION
This adds step by step example of writing kernel device driver for OLED LCD display based on ssd1306 controller.