### PR TITLE
ssd1306: simple driver with user application

### DIFF
--- a/sandbox/LICENSE
+++ b/sandbox/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    {project}  Copyright (C) {year}  {fullname}
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,0 +1,18 @@
+# SandBox for Linux kernel drivers learning
+
+## ssd1306
+A custom Linux Kernel module for the SSD1306 based 128x64 pixel OLED display.
+These displays are small, only about 1" diameter, but very readable due to the high contrast of an OLED display. This display is made of 128x64 individual white OLED pixels, each one is turned on or off by the controller chip. Because the display makes its own light, no backlight is required. 
+SSD1306 communicates via I2C serial interface.
+[DataSheet](https://www.olimex.com/Products/Modules/LCD/MOD-OLED-128x64/resources/SSD1306.pdf)
+
+## userapp_analog_clock
+A Linux userspace application. Draws a simple analog clock on fb0 FrameBuffer device.
+[Low-Level Graphics on Linux](http://betteros.org/tut/graphics1.php)
+
+![alt tag](https://www.mathworks.com/help/supportpkg/beagleboneio/ug/beaglebone_black_pinmap.png)
+
+$KERNEL/arch/arm/boot/dts/
+am335x-boneblack.dts
+am335x-bone-common.dtsi
+

--- a/sandbox/extra/lin.hdmi_disabled.diff
+++ b/sandbox/extra/lin.hdmi_disabled.diff
@@ -1,0 +1,929 @@
+diff --git a/arch/arm/boot/dts/am335x-abbbi.dts b/arch/arm/boot/dts/am335x-abbbi.dts
+index 43efead..2da56be 100644
+--- a/arch/arm/boot/dts/am335x-abbbi.dts
++++ b/arch/arm/boot/dts/am335x-abbbi.dts
+@@ -87,7 +87,7 @@
+ 		>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+ 	port {
+@@ -112,7 +112,7 @@
+ 		};
+ 	};
+ };
+-
++*/
+ &mcasp0	{
+ 	pinctrl-names = "default", "sleep";
+ 	pinctrl-0 = <&mcasp0_pins>;
+diff --git a/arch/arm/boot/dts/am335x-base0033.dts b/arch/arm/boot/dts/am335x-base0033.dts
+index c2bee45..3751efe 100644
+--- a/arch/arm/boot/dts/am335x-base0033.dts
++++ b/arch/arm/boot/dts/am335x-base0033.dts
+@@ -13,16 +13,16 @@
+ / {
+ 	model = "IGEP COM AM335x on AQUILA Expansion";
+ 	compatible = "isee,am335x-base0033", "isee,am335x-igep0033", "ti,am33xx";
+-
+-	hdmi {
+-		compatible = "ti,tilcdc,slave";
+-		i2c = <&i2c0>;
+-		pinctrl-names = "default", "off";
+-		pinctrl-0 = <&nxp_hdmi_pins>;
+-		pinctrl-1 = <&nxp_hdmi_off_pins>;
+-		status = "okay";
+-	};
+-
++/*
++	#hdmi {
++	#	compatible = "ti,tilcdc,slave";
++	#	i2c = <&i2c0>;
++	#	pinctrl-names = "default", "off";
++	#	pinctrl-0 = <&nxp_hdmi_pins>;
++	#	pinctrl-1 = <&nxp_hdmi_off_pins>;
++	#	status = "okay";
++	#};
++*/
+ 	leds_base {
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&leds_base_pins>;
+@@ -82,11 +82,11 @@
+ 		>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+ };
+-
++*/
+ &i2c0 {
+ 	eeprom: eeprom@50 {
+ 		compatible = "at,24c256";
+diff --git a/arch/arm/boot/dts/am335x-bone-common.dtsi b/arch/arm/boot/dts/am335x-bone-common.dtsi
+index 42005fe..2f43db8 100644
+--- a/arch/arm/boot/dts/am335x-bone-common.dtsi
++++ b/arch/arm/boot/dts/am335x-bone-common.dtsi
+@@ -6,8 +6,6 @@
+  * published by the Free Software Foundation.
+  */
+ 
+-#include <dt-bindings/mfd/tps65217.h>
+-
+ / {
+ 	cpus {
+ 		cpu@0 {
+@@ -15,43 +13,40 @@
+ 		};
+ 	};
+ 
+-	memory@80000000 {
++	memory {
+ 		device_type = "memory";
+ 		reg = <0x80000000 0x10000000>; /* 256 MB */
+ 	};
+ 
+-	chosen {
+-		stdout-path = &uart0;
+-	};
+-
+ 	leds {
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&user_leds_s0>;
++		pinctrl-names = "default", "sleep";
++		pinctrl-0 = <&user_leds_default>;
++		pinctrl-1 = <&user_leds_sleep>;
+ 
+ 		compatible = "gpio-leds";
+ 
+-		led2 {
++		led@2 {
+ 			label = "beaglebone:green:usr0";
+ 			gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+ 			linux,default-trigger = "heartbeat";
+ 			default-state = "off";
+ 		};
+ 
+-		led3 {
++		led@3 {
+ 			label = "beaglebone:green:usr1";
+ 			gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+ 			linux,default-trigger = "mmc0";
+ 			default-state = "off";
+ 		};
+ 
+-		led4 {
++		led@4 {
+ 			label = "beaglebone:green:usr2";
+ 			gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+ 			linux,default-trigger = "cpu0";
+ 			default-state = "off";
+ 		};
+ 
+-		led5 {
++		led@5 {
+ 			label = "beaglebone:green:usr3";
+ 			gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+ 			linux,default-trigger = "mmc1";
+@@ -59,7 +54,7 @@
+ 		};
+ 	};
+ 
+-	vmmcsd_fixed: fixedregulator0 {
++	vmmcsd_fixed: fixedregulator@0 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vmmcsd_fixed";
+ 		regulator-min-microvolt = <3300000>;
+@@ -68,7 +63,7 @@
+ };
+ 
+ &am33xx_pinmux {
+-	user_leds_s0: user_leds_s0 {
++	user_leds_default: user_leds_default {
+ 		pinctrl-single,pins = <
+ 			AM33XX_IOPAD(0x854, PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a5.gpio1_21 */
+ 			AM33XX_IOPAD(0x858, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* gpmc_a6.gpio1_22 */
+@@ -77,6 +72,15 @@
+ 		>;
+ 	};
+ 
++	user_leds_sleep: user_leds_sleep {
++		pinctrl-single,pins = <
++			AM33XX_IOPAD(0x854, PIN_INPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a5.gpio1_21 */
++			AM33XX_IOPAD(0x858, PIN_INPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a6.gpio1_22 */
++			AM33XX_IOPAD(0x85c, PIN_INPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a7.gpio1_23 */
++			AM33XX_IOPAD(0x860, PIN_INPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a8.gpio1_24 */
++		>;
++	};
++
+ 	i2c0_pins: pinmux_i2c0_pins {
+ 		pinctrl-single,pins = <
+ 			AM33XX_IOPAD(0x988, PIN_INPUT_PULLUP | MUX_MODE0)	/* i2c0_sda.i2c0_sda */
+@@ -84,12 +88,20 @@
+ 		>;
+ 	};
+ 
+-//	i2c2_pins: pinmux_i2c2_pins {
+-//		pinctrl-single,pins = <
+-//			AM33XX_IOPAD(0x978, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_ctsn.i2c2_sda */
+-//			AM33XX_IOPAD(0x97c, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_rtsn.i2c2_scl */
+-//		>;
+-//	};
++
++	i2c1_pins: pinmux_i2c1_pins {
++		pinctrl-single,pins = <
++			AM33XX_IOPAD(0x958, PIN_INPUT_PULLUP | MUX_MODE2)	/* i2c1_scl.i2c1_scl */
++			AM33XX_IOPAD(0x95c, PIN_INPUT_PULLUP | MUX_MODE2)	/* i2c1_sda.i2c1_sda */
++		>;
++	};
++
++	i2c2_pins: pinmux_i2c2_pins {
++		pinctrl-single,pins = <
++			AM33XX_IOPAD(0x978, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_ctsn.i2c2_sda */
++			AM33XX_IOPAD(0x97c, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_rtsn.i2c2_scl */
++		>;
++	};
+ 
+ 	uart0_pins: pinmux_uart0_pins {
+ 		pinctrl-single,pins = <
+@@ -176,46 +188,6 @@
+ 			AM33XX_IOPAD(0x81c, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad7.mmc1_dat7 */
+ 		>;
+ 	};
+-
+-	/* P9_19 (ZCZ ball D17) i2c */
+-	P9_19_default_pin: pinmux_P9_19_default_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* uart1_rtsn.i2c2_scl */
+-	P9_19_gpio_pin: pinmux_P9_19_gpio_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x097c, PIN_OUTPUT | INPUT_EN | MUX_MODE7) >; };	/* uart1_rtsn.gpio0_13 */
+-	P9_19_gpio_pu_pin: pinmux_P9_19_gpio_pu_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE7) >; };	/* uart1_rtsn.gpio0_13 */
+-	P9_19_gpio_pd_pin: pinmux_P9_19_gpio_pd_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* uart1_rtsn.gpio0_13 */
+-	P9_19_spi_cs_pin: pinmux_P9_19_spi_cs_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE4) >; };	/* uart1_rtsn.spi1_cs1 */
+-	P9_19_i2c_pin: pinmux_P9_19_i2c_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* uart1_rtsn.i2c2_scl */
+-	P9_19_can_pin: pinmux_P9_19_can_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x097c, PIN_INPUT_PULLUP | MUX_MODE2) >; };		/* uart1_rtsn.dcan0_rx */
+-	P9_19_pru_uart_pin: pinmux_P9_19_pru_uart_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE5) >; };	/* uart1_rtsn.pr1_uart0_rts_n */
+-	P9_19_timer_pin: pinmux_P9_19_timer_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x097c, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE1) >; };	/* uart1_rtsn.timer5 */
+-
+-	/* P9_20 (ZCZ ball D18) i2c */
+-	P9_20_default_pin: pinmux_P9_20_default_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* uart1_ctsn.i2c2_sda */
+-	P9_20_gpio_pin: pinmux_P9_20_gpio_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x0978, PIN_OUTPUT | INPUT_EN | MUX_MODE7) >; };	/* uart1_ctsn.gpio0_12 */
+-	P9_20_gpio_pu_pin: pinmux_P9_20_gpio_pu_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE7) >; };	/* uart1_ctsn.gpio0_12 */
+-	P9_20_gpio_pd_pin: pinmux_P9_20_gpio_pd_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* uart1_ctsn.gpio0_12 */
+-	P9_20_spi_cs_pin: pinmux_P9_20_spi_cs_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE4) >; };	/* uart1_ctsn.spi1_cs0 */
+-	P9_20_i2c_pin: pinmux_P9_20_i2c_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* uart1_ctsn.i2c2_sda */
+-	P9_20_can_pin: pinmux_P9_20_can_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x0978, PIN_INPUT_PULLUP | MUX_MODE2) >; };		/* uart1_ctsn.dcan0_tx */
+-	P9_20_pru_uart_pin: pinmux_P9_20_pru_uart_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE5) >; };	/* uart1_ctsn.pr1_uart0_cts_n */
+-	P9_20_timer_pin: pinmux_P9_20_timer_pin { pinctrl-single,pins = <
+-		AM33XX_IOPAD(0x0978, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE1) >; };	/* uart1_ctsn.timer6 */
+ };
+ 
+ &uart0 {
+@@ -266,64 +238,37 @@
+ 		reg = <0x24>;
+ 	};
+ 
+-	baseboard_eeprom: baseboard_eeprom@50 {
+-		compatible = "at,24c256";
+-		reg = <0x50>;
+-
+-		#address-cells = <1>;
+-		#size-cells = <1>;
+-		baseboard_data: baseboard_data@0 {
+-			reg = <0 0x100>;
+-		};
+-	};
+ };
+ 
+-&i2c2 {
++
++&i2c1 {
+ 	pinctrl-names = "default";
+-	//pinctrl-0 = <&i2c2_pins>;
+-	pinctrl-0 = <>;
++	pinctrl-0 = <&i2c1_pins>;
+ 
+ 	status = "okay";
+-	clock-frequency = <100000>;
+-
+-	cape_eeprom0: cape_eeprom0@54 {
+-		compatible = "at,24c256";
+-		reg = <0x54>;
+-		#address-cells = <1>;
+-		#size-cells = <1>;
+-		cape0_data: cape_data@0 {
+-			reg = <0 0x100>;
+-		};
+-	};
++	clock-frequency = <400000>;
+ 
+-	cape_eeprom1: cape_eeprom1@55 {
+-		compatible = "at,24c256";
+-		reg = <0x55>;
+-		#address-cells = <1>;
+-		#size-cells = <1>;
+-		cape1_data: cape_data@0 {
+-			reg = <0 0x100>;
+-		};
+-	};
+ 
+-	cape_eeprom2: cape_eeprom2@56 {
+-		compatible = "at,24c256";
+-		reg = <0x56>;
+-		#address-cells = <1>;
+-		#size-cells = <1>;
+-		cape2_data: cape_data@0 {
+-			reg = <0 0x100>;
+-		};
++	lcd_ssd1306: lcd_ssd1306@3c {
++		compatible = "DAndy,lcd_ssd1306";
++		reg = <0x3c>;
++		status = "okay";
++
+ 	};
++};
+ 
+-	cape_eeprom3: cape_eeprom3@57 {
+-		compatible = "at,24c256";
+-		reg = <0x57>;
+-		#address-cells = <1>;
+-		#size-cells = <1>;
+-		cape3_data: cape_data@0 {
+-			reg = <0 0x100>;
+-		};
++
++&i2c2 {
++    pinctrl-names = "default";
++    pinctrl-0 = <&i2c2_pins>;
++
++    status = "okay";
++    clock-frequency = <100000>;
++
++    gl_gyro: gl_gyro@68 {
++        compatible = "gl,mpu6050";
++        reg = <0x68>;
++        status = "okay";
+ 	};
+ };
+ 
+@@ -348,22 +293,10 @@
+ 	 * by the hardware problems. (Tip: double-check by performing a current
+ 	 * measurement after shutdown: it should be less than 1 mA.)
+ 	 */
+-
+-	interrupts = <7>; /* NMI */
+-	interrupt-parent = <&intc>;
+-
+ 	ti,pmic-shutdown-controller;
+ 
+-	charger {
+-		interrupts = <TPS65217_IRQ_AC>, <TPS65217_IRQ_USB>;
+-		interrupts-names = "AC", "USB";
+-		status = "okay";
+-	};
+-
+-	pwrbutton {
+-		interrupts = <TPS65217_IRQ_PB>;
+-		status = "okay";
+-	};
++	interrupt-parent = <&intc>;
++	interrupts = <7>;	/* NNMI */
+ 
+ 	regulators {
+ 		dcdc1_reg: regulator@0 {
+@@ -417,10 +350,10 @@
+ };
+ 
+ &mac {
+-	slaves = <1>;
+ 	pinctrl-names = "default", "sleep";
+ 	pinctrl-0 = <&cpsw_default>;
+ 	pinctrl-1 = <&cpsw_sleep>;
++	slaves = <1>;
+ 	status = "okay";
+ };
+ 
+@@ -447,30 +380,18 @@
+ 	status = "okay";
+ };
+ 
++&wkup_m3_ipc {
++	ti,scale-data-fw = "am335x-bone-scale-data.bin";
++};
++
+ &rtc {
+ 	clocks = <&clk_32768_ck>, <&clkdiv32k_ick>;
+ 	clock-names = "ext-clk", "int-clk";
+ 	system-power-controller;
+ };
+ 
+-&wkup_m3_ipc {
+-	ti,scale-data-fw = "am335x-bone-scale-data.bin";
+-};
+-
+-&pruss_soc_bus {
++&sgx {
+ 	status = "okay";
+-
+-	pruss: pruss@4a300000 {
+-		status = "okay";
+-
+-		pru0: pru@4a334000 {
+-			status = "okay";
+-		};
+-
+-		pru1: pru@4a338000 {
+-			status = "okay";
+-		};
+-	};
+ };
+ 
+ /* the cape manager */
+@@ -479,7 +400,7 @@
+ 		compatible = "ti,bone-capemgr";
+ 		status = "okay";
+ 
+-		nvmem-cells = <&baseboard_data &cape0_data &cape1_data &cape2_data &cape3_data>;
++		/* nvmem-cells = <&baseboard_data &cape0_data &cape1_data &cape2_data &cape3_data>; */
+ 		nvmem-cell-names = "baseboard", "slot0", "slot1", "slot2", "slot3";
+ 		#slots = <4>;
+ 
+@@ -497,60 +418,3 @@
+ 		};
+ 	};
+ };
+-
+-&ocp {
+-	/* P9_19 (ZCZ ball D17) i2c */
+-	P9_19_pinmux {
+-		compatible = "bone-pinmux-helper";
+-		status = "okay";
+-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "spi_cs", "can", "i2c", "pru_uart", "timer";
+-		pinctrl-0 = <&P9_19_default_pin>;
+-		pinctrl-1 = <&P9_19_gpio_pin>;
+-		pinctrl-2 = <&P9_19_gpio_pu_pin>;
+-		pinctrl-3 = <&P9_19_gpio_pd_pin>;
+-		pinctrl-4 = <&P9_19_spi_cs_pin>;
+-		pinctrl-5 = <&P9_19_can_pin>;
+-		pinctrl-6 = <&P9_19_i2c_pin>;
+-		pinctrl-7 = <&P9_19_pru_uart_pin>;
+-		pinctrl-8 = <&P9_19_timer_pin>;
+-	};
+-
+-	/* P9_20 (ZCZ ball D18) i2c */
+-	P9_20_pinmux {
+-		compatible = "bone-pinmux-helper";
+-		status = "okay";
+-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "spi_cs", "can", "i2c", "pru_uart", "timer";
+-		pinctrl-0 = <&P9_20_default_pin>;
+-		pinctrl-1 = <&P9_20_gpio_pin>;
+-		pinctrl-2 = <&P9_20_gpio_pu_pin>;
+-		pinctrl-3 = <&P9_20_gpio_pd_pin>;
+-		pinctrl-4 = <&P9_20_spi_cs_pin>;
+-		pinctrl-5 = <&P9_20_can_pin>;
+-		pinctrl-6 = <&P9_20_i2c_pin>;
+-		pinctrl-7 = <&P9_20_pru_uart_pin>;
+-		pinctrl-8 = <&P9_20_timer_pin>;
+-	};
+-
+-
+-	cape-universal {
+-		compatible = "gpio-of-helper";
+-		status = "okay";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <>;
+-
+-		P9_19 {
+-			gpio-name = "P9_19";
+-			gpio = <&gpio0 13 0>;
+-			input;
+-			dir-changeable;
+-		};
+-
+-		P9_20 {
+-			gpio-name = "P9_20";
+-			gpio = <&gpio0 12 0>;
+-			input;
+-			dir-changeable;
+-		};
+-
+-	};
+-};
+diff --git a/arch/arm/boot/dts/am335x-boneblack-cape-bone-argus.dts b/arch/arm/boot/dts/am335x-boneblack-cape-bone-argus.dts
+index c97c912..e77e2a0 100644
+--- a/arch/arm/boot/dts/am335x-boneblack-cape-bone-argus.dts
++++ b/arch/arm/boot/dts/am335x-boneblack-cape-bone-argus.dts
+@@ -76,7 +76,7 @@
+ 		>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+ 	port {
+@@ -101,5 +101,5 @@
+ 		};
+ 	};
+ };
+-
++*/
+ #include "am335x-bone-argus.dtsi"
+diff --git a/arch/arm/boot/dts/am335x-boneblack-hdmi-overlay.dts b/arch/arm/boot/dts/am335x-boneblack-hdmi-overlay.dts
+index ec19dad..206c8bd 100644
+--- a/arch/arm/boot/dts/am335x-boneblack-hdmi-overlay.dts
++++ b/arch/arm/boot/dts/am335x-boneblack-hdmi-overlay.dts
+@@ -90,16 +90,16 @@
+ 		>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+-
++*/
+ 	/* If you want to get 24 bit RGB and 16 BGR mode instead of
+ 	 * current 16 bit RGB and 24 BGR modes, set the propety
+ 	 * below to "crossed" and uncomment the video-ports -property
+ 	 * in tda19988 node.
+ 	 */
+-	blue-and-red-wiring = "straight";
++/*	blue-and-red-wiring = "straight";
+ 
+ 	port {
+ 		lcdc_0: endpoint@0 {
+@@ -116,10 +116,10 @@
+ 		pinctrl-names = "default", "off";
+ 		pinctrl-0 = <&nxp_hdmi_bonelt_pins>;
+ 		pinctrl-1 = <&nxp_hdmi_bonelt_off_pins>;
+-
++*/
+ 		/* Convert 24bit BGR to RGB, e.g. cross red and blue wiring */
+ 		/* video-ports = <0x234501>; */
+-
++/*
+ 		#sound-dai-cells = <0>;
+ 		audio-ports = <	TDA998x_I2S	0x03>;
+ 
+@@ -132,7 +132,7 @@
+ 		};
+ 	};
+ };
+-
++*/
+ &mcasp0	{
+ 	#sound-dai-cells = <0>;
+ 	pinctrl-names = "default";
+@@ -176,9 +176,10 @@
+ 			sound-dai = <&mcasp0>;
+ 			clocks = <&clk_mcasp0>;
+ 		};
+-
++/*
+ 		simple-audio-card,codec {
+ 			sound-dai = <&tda19988>;
+ 		};
++*/
+ 	};
+ };
+diff --git a/arch/arm/boot/dts/am335x-boneblack-nhdmi-overlay.dts b/arch/arm/boot/dts/am335x-boneblack-nhdmi-overlay.dts
+index 5433aa1..2adbfd6 100644
+--- a/arch/arm/boot/dts/am335x-boneblack-nhdmi-overlay.dts
++++ b/arch/arm/boot/dts/am335x-boneblack-nhdmi-overlay.dts
+@@ -80,16 +80,16 @@
+ 		>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+-
++*/
+ 	/* If you want to get 24 bit RGB and 16 BGR mode instead of
+ 	 * current 16 bit RGB and 24 BGR modes, set the propety
+ 	 * below to "crossed" and uncomment the video-ports -property
+ 	 * in tda19988 node.
+ 	 */
+-	blue-and-red-wiring = "straight";
++/*	blue-and-red-wiring = "straight";
+ 
+ 	port {
+ 		lcdc_0: endpoint@0 {
+@@ -106,10 +106,10 @@
+ 		pinctrl-names = "default", "off";
+ 		pinctrl-0 = <&nxp_hdmi_bonelt_pins>;
+ 		pinctrl-1 = <&nxp_hdmi_bonelt_off_pins>;
+-
++*/
+ 		/* Convert 24bit BGR to RGB, e.g. cross red and blue wiring */
+ 		/* video-ports = <0x234501>; */
+-
++/*
+ 		ports {
+ 			port@0 {
+ 				hdmi_0: endpoint@0 {
+@@ -119,7 +119,7 @@
+ 		};
+ 	};
+ };
+-
++*/
+ &sgx {
+ 	status = "okay";
+ };
+diff --git a/arch/arm/boot/dts/am335x-boneblack-wireless.dts b/arch/arm/boot/dts/am335x-boneblack-wireless.dts
+index 9b39648..3c82e1d 100644
+--- a/arch/arm/boot/dts/am335x-boneblack-wireless.dts
++++ b/arch/arm/boot/dts/am335x-boneblack-wireless.dts
+@@ -86,7 +86,7 @@
+ 		>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+ 	port {
+@@ -95,7 +95,8 @@
+ 		};
+ 	};
+ };
+-
++*/
++/*
+ &i2c0 {
+ 	tda19988: tda19988 {
+ 		compatible = "nxp,tda998x";
+@@ -117,7 +118,7 @@
+ 		};
+ 	};
+ };
+-
++*/
+ &mcasp0	{
+ 	#sound-dai-cells = <0>;
+ 	pinctrl-names = "default";
+@@ -157,9 +158,10 @@
+ 			sound-dai = <&mcasp0>;
+ 			clocks = <&clk_mcasp0>;
+ 		};
+-
++/*
+ 		simple-audio-card,codec {
+ 			sound-dai = <&tda19988>;
+ 		};
++*/
+ 	};
+ };
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
+index e457368..e7fcca0 100644
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
+@@ -88,16 +88,16 @@
+ 		>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+-
++*/
+ 	/* If you want to get 24 bit RGB and 16 BGR mode instead of
+ 	 * current 16 bit RGB and 24 BGR modes, set the propety
+ 	 * below to "crossed" and uncomment the video-ports -property
+ 	 * in tda19988 node.
+ 	 */
+-	blue-and-red-wiring = "straight";
++/*	blue-and-red-wiring = "straight";
+ 
+ 	port {
+ 		lcdc_0: endpoint@0 {
+@@ -114,10 +114,10 @@
+ 		pinctrl-names = "default", "off";
+ 		pinctrl-0 = <&nxp_hdmi_bonelt_pins>;
+ 		pinctrl-1 = <&nxp_hdmi_bonelt_off_pins>;
+-
++*/
+ 		/* Convert 24bit BGR to RGB, e.g. cross red and blue wiring */
+ 		/* video-ports = <0x234501>; */
+-
++/*
+ 		#sound-dai-cells = <0>;
+ 		audio-ports = <	TDA998x_I2S	0x03>;
+ 
+@@ -130,7 +130,7 @@
+ 		};
+ 	};
+ };
+-
++*/
+ &mcasp0	{
+ 	#sound-dai-cells = <0>;
+ 	pinctrl-names = "default";
+@@ -174,9 +174,10 @@
+ 			sound-dai = <&mcasp0>;
+ 			clocks = <&clk_mcasp0>;
+ 		};
+-
++/*
+ 		simple-audio-card,codec {
+ 			sound-dai = <&tda19988>;
+ 		};
++*/
+ 	};
+ };
+diff --git a/arch/arm/boot/dts/am335x-evm.dts b/arch/arm/boot/dts/am335x-evm.dts
+index 4538a46..32c9c56b 100644
+--- a/arch/arm/boot/dts/am335x-evm.dts
++++ b/arch/arm/boot/dts/am335x-evm.dts
+@@ -499,13 +499,13 @@
+ 		DVDD-supply = <&vbat>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+ 
+ 	blue-and-red-wiring = "crossed";
+ };
+-
++*/
+ &elm {
+ 	status = "okay";
+ };
+diff --git a/arch/arm/boot/dts/am335x-evmsk.dts b/arch/arm/boot/dts/am335x-evmsk.dts
+index dc52d9df..c001b1e 100644
+--- a/arch/arm/boot/dts/am335x-evmsk.dts
++++ b/arch/arm/boot/dts/am335x-evmsk.dts
+@@ -727,13 +727,13 @@
+ 		ti,wire-config = <0x00 0x11 0x22 0x33>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+ 
+ 	blue-and-red-wiring = "crossed";
+ };
+-
++*/
+ &sgx {
+ 	status = "okay";
+ };
+diff --git a/arch/arm/boot/dts/am335x-olimex-som.dts b/arch/arm/boot/dts/am335x-olimex-som.dts
+index 2b00ad2..7546ec1 100644
+--- a/arch/arm/boot/dts/am335x-olimex-som.dts
++++ b/arch/arm/boot/dts/am335x-olimex-som.dts
+@@ -95,12 +95,13 @@
+ 	};
+ 
+ };
+-
++/*
+ &lcdc {
+ 	pinctrl-names = "default", "sleep";
+ 	pinctrl-0 = <&lcd_pins_default>;
+ 	pinctrl-1 = <&lcd_pins_sleep>;
+ 	status = "okay";
++*/
+ 	/*        display-timings {
+ 	 480x272 {
+ 	 hactive         = <480>;
+@@ -116,7 +117,7 @@
+ 	 vsync-active    = <0>;
+ 	 };
+ 	 };*/
+-
++/*
+ 	display-timings {
+ 		native-mode = <&vga1024x768>;
+ 		lcd4: 480x272 {
+@@ -187,3 +188,4 @@
+ 		};
+ 	};
+ };
++*/
+diff --git a/arch/arm/boot/dts/am335x-pepper.dts b/arch/arm/boot/dts/am335x-pepper.dts
+index adc000c..ca222de 100644
+--- a/arch/arm/boot/dts/am335x-pepper.dts
++++ b/arch/arm/boot/dts/am335x-pepper.dts
+@@ -220,11 +220,11 @@
+ 		};
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+ };
+-
++*/
+ &am33xx_pinmux {
+ 	lcd_pins: pinmux_lcd {
+ 		pinctrl-single,pins = <
+diff --git a/arch/arm/boot/dts/am335x-peripheral-panel-1024x600-24bit.dtsi b/arch/arm/boot/dts/am335x-peripheral-panel-1024x600-24bit.dtsi
+index f7c8f8af..a55af90 100644
+--- a/arch/arm/boot/dts/am335x-peripheral-panel-1024x600-24bit.dtsi
++++ b/arch/arm/boot/dts/am335x-peripheral-panel-1024x600-24bit.dtsi
+@@ -5,12 +5,12 @@
+  * it under the terms of the GNU General Public License version 2 as
+  * published by the Free Software Foundation.
+  */
+-
++/*
+ &lcdc {
+ 	status = "okay";
+ 	blue-and-red-wiring = "crossed";
+ };
+-
++*/
+ / {
+ 	panel {
+ 		status = "okay";
+diff --git a/arch/arm/boot/dts/am335x-sancloud-bbe.dts b/arch/arm/boot/dts/am335x-sancloud-bbe.dts
+index 3c72036..21a1740 100644
+--- a/arch/arm/boot/dts/am335x-sancloud-bbe.dts
++++ b/arch/arm/boot/dts/am335x-sancloud-bbe.dts
+@@ -152,16 +152,16 @@
+ 		>;
+ 	};
+ };
+-
++/*
+ &lcdc {
+ 	status = "okay";
+-
++*/
+ 	/* If you want to get 24 bit RGB and 16 BGR mode instead of
+ 	 * current 16 bit RGB and 24 BGR modes, set the propety
+ 	 * below to "crossed" and uncomment the video-ports -property
+ 	 * in tda19988 node.
+ 	 */
+-	blue-and-red-wiring = "straight";
++/*	blue-and-red-wiring = "straight";
+ 
+ 	port {
+ 		lcdc_0: endpoint@0 {
+@@ -169,7 +169,7 @@
+ 		};
+ 	};
+ };
+-
++*/
+ &mac {
+ 	pinctrl-names = "default", "sleep";
+ 	pinctrl-0 = <&cpsw_default>;
+@@ -188,6 +188,7 @@
+ };
+ 
+ &i2c0 {
++/*
+ 	tda19988: tda19988 {
+ 		compatible = "nxp,tda998x";
+ 		reg = <0x70>;
+@@ -195,10 +196,10 @@
+ 		pinctrl-names = "default", "off";
+ 		pinctrl-0 = <&nxp_hdmi_bonelt_pins>;
+ 		pinctrl-1 = <&nxp_hdmi_bonelt_off_pins>;
+-
++*/
+ 		/* Convert 24bit BGR to RGB, e.g. cross red and blue wiring */
+ 		/* video-ports = <0x234501>; */
+-
++/*
+ 		#sound-dai-cells = <0>;
+ 		audio-ports = <	TDA998x_I2S	0x03>;
+ 
+@@ -210,7 +211,7 @@
+ 			};
+ 		};
+ 	};
+-
++*/
+ 	lps331ap: lps331ap@5C {
+ 		compatible = "st,lps331ap";
+ 		st,drdy-int-pin = <1>;
+@@ -271,9 +272,10 @@
+ 			sound-dai = <&mcasp0>;
+ 			clocks = <&clk_mcasp0>;
+ 		};
+-
++/*
+ 		simple-audio-card,codec {
+ 			sound-dai = <&tda19988>;
+ 		};
++*/
+ 	};
+ };
+diff --git a/arch/arm/boot/dts/am33xx.dtsi b/arch/arm/boot/dts/am33xx.dtsi
+index 48ef93d..6d8adcd 100644
+--- a/arch/arm/boot/dts/am33xx.dtsi
++++ b/arch/arm/boot/dts/am33xx.dtsi
+@@ -1062,11 +1062,12 @@
+ 		};
+ 
+ 		lcdc: lcdc@4830e000 {
+-			compatible = "ti,am33xx-tilcdc";
++			/*compatible = "ti,am33xx-tilcdc";
+ 			reg = <0x4830e000 0x1000>;
+ 			interrupt-parent = <&intc>;
+ 			interrupts = <36>;
+ 			ti,hwmods = "lcdc";
++*/
+ 			status = "disabled";
+ 		};
+ 
+diff --git a/drivers/char/Kconfig b/drivers/char/Kconfig
+index 8453a49..051d65b 100644
+--- a/drivers/char/Kconfig
++++ b/drivers/char/Kconfig
+@@ -6,6 +6,13 @@ menu "Character devices"
+ 
+ source "drivers/tty/Kconfig"
+ 
++config MPU6050_CDEV
++	bool "Added cdevs for mpu6050"
++	default y
++	help
++	  Say Y here if you want to support the /dev/mpu6050_line
++	  and /dev/mpu6050_full devices.
++	
+ config DEVMEM
+ 	bool "/dev/mem virtual device support"
+ 	default y
+diff --git a/drivers/char/Makefile b/drivers/char/Makefile
+index 6e6c244..a1f9f69 100644
+--- a/drivers/char/Makefile
++++ b/drivers/char/Makefile
+@@ -2,6 +2,7 @@
+ # Makefile for the kernel character device drivers.
+ #
+ 
++obj-$(CONFIG_MPU6050_CDEV)      += mpu6050/
+ obj-y				+= mem.o random.o
+ obj-$(CONFIG_TTY_PRINTK)	+= ttyprintk.o
+ obj-y				+= misc.o

--- a/sandbox/extra/uEnv.txt
+++ b/sandbox/extra/uEnv.txt
@@ -1,0 +1,73 @@
+#Docs: http://elinux.org/Beagleboard:U-boot_partitioning_layout_2.0
+
+uname_r=4.9.59+
+#uuid=
+#dtb=
+
+
+###U-Boot Overlays###
+###Documentation: http://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays
+###Master Enable
+#enable_uboot_overlays=1
+###
+###Overide capes with eeprom
+#uboot_overlay_addr0=/lib/firmware/<file0>.dtbo
+#uboot_overlay_addr1=/lib/firmware/<file1>.dtbo
+#uboot_overlay_addr2=/lib/firmware/<file2>.dtbo
+#uboot_overlay_addr3=/lib/firmware/<file3>.dtbo
+###
+###Additional custom capes
+#uboot_overlay_addr4=/lib/firmware/<file4>.dtbo
+#uboot_overlay_addr5=/lib/firmware/<file5>.dtbo
+#uboot_overlay_addr6=/lib/firmware/<file6>.dtbo
+#uboot_overlay_addr7=/lib/firmware/<file7>.dtbo
+###
+###Custom Cape
+#dtb_overlay=/lib/firmware/<file8>.dtbo
+###
+###Disable auto loading of virtual capes (emmc/video/wireless/adc)
+#disable_uboot_overlay_emmc=1
+#disable_uboot_overlay_video=1
+#disable_uboot_overlay_audio=1
+#disable_uboot_overlay_wireless=1
+#disable_uboot_overlay_adc=1
+###
+###PRUSS OPTIONS
+###pru_rproc (4.4.x-ti kernel)
+#uboot_overlay_pru=/lib/firmware/AM335X-PRU-RPROC-4-4-TI-00A0.dtbo
+###pru_uio (4.4.x-ti & mainline/bone kernel)
+#uboot_overlay_pru=/lib/firmware/AM335X-PRU-UIO-00A0.dtbo
+###
+###Cape Universal Enable
+#enable_uboot_cape_universal=1
+###
+###Debug: disable uboot autoload of Cape
+#disable_uboot_overlay_addr0=1
+#disable_uboot_overlay_addr1=1
+#disable_uboot_overlay_addr2=1
+#disable_uboot_overlay_addr3=1
+###
+###U-Boot fdt tweaks...
+#uboot_fdt_buffer=0x60000
+###U-Boot Overlays###
+
+cmdline=coherent_pool=1M net.ifnames=0 quiet
+
+#In the event of edid real failures, uncomment this next line:
+#cmdline=coherent_pool=1M net.ifnames=0 quiet video=HDMI-A-1:1024x768@60e
+
+##Example v3.8.x
+#cape_disable=capemgr.disable_partno=
+#cape_enable=capemgr.enable_partno=
+
+##Example v4.1.x
+#cape_disable=bone_capemgr.disable_partno=
+#cape_enable=bone_capemgr.enable_partno=
+
+##Example v4.9.x
+cape_disable=bone_capemgr.disable_partno=BB-HDMI-TDA998x,BB-NHDMI-TDA998x,BB-SPIDEV0,BB-SPI0-ADS8688,BB-SPI0-MCP3008,BB-BBBMINI
+
+##enable Generic eMMC Flasher:
+##make sure, these tools are installed: dosfstools rsync
+#cmdline=init=/opt/scripts/tools/eMMC/init-eMMC-flasher-v3.sh
+

--- a/sandbox/ssd1306/Makefile
+++ b/sandbox/ssd1306/Makefile
@@ -1,0 +1,22 @@
+CONFIG_MODULE_SIG=n
+
+obj-m := ssd1306.o
+
+KDIR ?= ${HOME}/BBB/bb_kernel/
+#KDIR ?= ~/BBB/KERNEL/
+
+PWD := $(shell pwd)
+
+default:
+		  $(MAKE) ARCH=arm  -C $(KDIR) M=$(PWD) modules
+
+clean:
+		  $(MAKE) ARCH=arm  -C $(KDIR) SUBDIRS=$(PWD) clean
+
+config:
+		$(MAKE) ARCH=arm -C $(KDIR) menuconfig
+
+dtb:
+		$(MAKE) ARCH=arm -C $(KDIR) dtbs
+
+.PHONY: clean default config dtb

--- a/sandbox/ssd1306/am335x-bone-common.dtsi
+++ b/sandbox/ssd1306/am335x-bone-common.dtsi
@@ -1,0 +1,420 @@
+/*
+ * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/ {
+	cpus {
+		cpu@0 {
+			cpu0-supply = <&dcdc2_reg>;
+		};
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>; /* 256 MB */
+	};
+
+	leds {
+		pinctrl-names = "default", "sleep";
+		pinctrl-0 = <&user_leds_default>;
+		pinctrl-1 = <&user_leds_sleep>;
+
+		compatible = "gpio-leds";
+
+		led@2 {
+			label = "beaglebone:green:usr0";
+			gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+			default-state = "off";
+		};
+
+		led@3 {
+			label = "beaglebone:green:usr1";
+			gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mmc0";
+			default-state = "off";
+		};
+
+		led@4 {
+			label = "beaglebone:green:usr2";
+			gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "cpu0";
+			default-state = "off";
+		};
+
+		led@5 {
+			label = "beaglebone:green:usr3";
+			gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mmc1";
+			default-state = "off";
+		};
+	};
+
+	vmmcsd_fixed: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vmmcsd_fixed";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+	};
+};
+
+&am33xx_pinmux {
+	user_leds_default: user_leds_default {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x854, PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a5.gpio1_21 */
+			AM33XX_IOPAD(0x858, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* gpmc_a6.gpio1_22 */
+			AM33XX_IOPAD(0x85c, PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a7.gpio1_23 */
+			AM33XX_IOPAD(0x860, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* gpmc_a8.gpio1_24 */
+		>;
+	};
+
+	user_leds_sleep: user_leds_sleep {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x854, PIN_INPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a5.gpio1_21 */
+			AM33XX_IOPAD(0x858, PIN_INPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a6.gpio1_22 */
+			AM33XX_IOPAD(0x85c, PIN_INPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a7.gpio1_23 */
+			AM33XX_IOPAD(0x860, PIN_INPUT_PULLDOWN | MUX_MODE7)	/* gpmc_a8.gpio1_24 */
+		>;
+	};
+
+	i2c0_pins: pinmux_i2c0_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x988, PIN_INPUT_PULLUP | MUX_MODE0)	/* i2c0_sda.i2c0_sda */
+			AM33XX_IOPAD(0x98c, PIN_INPUT_PULLUP | MUX_MODE0)	/* i2c0_scl.i2c0_scl */
+		>;
+	};
+
+
+	i2c1_pins: pinmux_i2c1_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x958, PIN_INPUT_PULLUP | MUX_MODE2)	/* i2c1_scl.i2c1_scl */
+			AM33XX_IOPAD(0x95c, PIN_INPUT_PULLUP | MUX_MODE2)	/* i2c1_sda.i2c1_sda */
+		>;
+	};
+
+	i2c2_pins: pinmux_i2c2_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x978, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_ctsn.i2c2_sda */
+			AM33XX_IOPAD(0x97c, PIN_INPUT_PULLUP | MUX_MODE3)	/* uart1_rtsn.i2c2_scl */
+		>;
+	};
+
+	uart0_pins: pinmux_uart0_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x970, PIN_INPUT_PULLUP | MUX_MODE0)	/* uart0_rxd.uart0_rxd */
+			AM33XX_IOPAD(0x974, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* uart0_txd.uart0_txd */
+		>;
+	};
+
+	cpsw_default: cpsw_default {
+		pinctrl-single,pins = <
+			/* Slave 1 */
+			0x108 (PIN_INPUT | MUX_MODE0)		/* mii1_col.mii1_col */
+			0x10c (PIN_INPUT | MUX_MODE0)		/* mii1_crs.mii1_crs */
+			AM33XX_IOPAD(0x910, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxerr.mii1_rxerr */
+			AM33XX_IOPAD(0x914, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txen.mii1_txen */
+			AM33XX_IOPAD(0x918, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxdv.mii1_rxdv */
+			AM33XX_IOPAD(0x91c, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txd3.mii1_txd3 */
+			AM33XX_IOPAD(0x920, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txd2.mii1_txd2 */
+			AM33XX_IOPAD(0x924, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txd1.mii1_txd1 */
+			AM33XX_IOPAD(0x928, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* mii1_txd0.mii1_txd0 */
+			AM33XX_IOPAD(0x92c, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_txclk.mii1_txclk */
+			AM33XX_IOPAD(0x930, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxclk.mii1_rxclk */
+			AM33XX_IOPAD(0x934, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxd3.mii1_rxd3 */
+			AM33XX_IOPAD(0x938, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxd2.mii1_rxd2 */
+			AM33XX_IOPAD(0x93c, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxd1.mii1_rxd1 */
+			AM33XX_IOPAD(0x940, PIN_INPUT_PULLUP | MUX_MODE0)	/* mii1_rxd0.mii1_rxd0 */
+		>;
+	};
+
+	cpsw_sleep: cpsw_sleep {
+		pinctrl-single,pins = <
+			/* Slave 1 reset value */
+			0x108 (PIN_INPUT_PULLDOWN | MUX_MODE7)
+			0x10c (PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x910, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x914, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x918, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x91c, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x920, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x924, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x928, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x92c, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x930, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x934, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x938, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x93c, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x940, PIN_INPUT_PULLDOWN | MUX_MODE7)
+		>;
+	};
+
+	davinci_mdio_default: davinci_mdio_default {
+		pinctrl-single,pins = <
+			/* MDIO */
+			AM33XX_IOPAD(0x948, PIN_INPUT_PULLUP | SLEWCTRL_FAST | MUX_MODE0)	/* mdio_data.mdio_data */
+			AM33XX_IOPAD(0x94c, PIN_OUTPUT_PULLUP | MUX_MODE0)			/* mdio_clk.mdio_clk */
+		>;
+	};
+
+	davinci_mdio_sleep: davinci_mdio_sleep {
+		pinctrl-single,pins = <
+			/* MDIO reset value */
+			AM33XX_IOPAD(0x948, PIN_INPUT_PULLDOWN | MUX_MODE7)
+			AM33XX_IOPAD(0x94c, PIN_INPUT_PULLDOWN | MUX_MODE7)
+		>;
+	};
+
+	mmc1_pins: pinmux_mmc1_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x960, PIN_INPUT | MUX_MODE7) /* GPIO0_6 */
+		>;
+	};
+
+	emmc_pins: pinmux_emmc_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x880, PIN_INPUT_PULLUP | MUX_MODE2) /* gpmc_csn1.mmc1_clk */
+			AM33XX_IOPAD(0x884, PIN_INPUT_PULLUP | MUX_MODE2) /* gpmc_csn2.mmc1_cmd */
+			AM33XX_IOPAD(0x800, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad0.mmc1_dat0 */
+			AM33XX_IOPAD(0x804, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad1.mmc1_dat1 */
+			AM33XX_IOPAD(0x808, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad2.mmc1_dat2 */
+			AM33XX_IOPAD(0x80c, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad3.mmc1_dat3 */
+			AM33XX_IOPAD(0x810, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad4.mmc1_dat4 */
+			AM33XX_IOPAD(0x814, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad5.mmc1_dat5 */
+			AM33XX_IOPAD(0x818, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad6.mmc1_dat6 */
+			AM33XX_IOPAD(0x81c, PIN_INPUT_PULLUP | MUX_MODE1) /* gpmc_ad7.mmc1_dat7 */
+		>;
+	};
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_ctrl_mod {
+	status = "okay";
+};
+
+&usb0_phy {
+	status = "okay";
+};
+
+&usb1_phy {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	dr_mode = "peripheral";
+};
+
+&usb1 {
+	status = "okay";
+	dr_mode = "host";
+};
+
+&cppi41dma  {
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+
+	status = "okay";
+	clock-frequency = <400000>;
+
+	tps: tps@24 {
+		reg = <0x24>;
+	};
+
+};
+
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1_pins>;
+
+	status = "okay";
+	clock-frequency = <400000>;
+
+
+	lcd_ssd1306: lcd_ssd1306@3c {
+		compatible = "DAndy,lcd_ssd1306";
+		reg = <0x3c>;
+		status = "okay";
+
+	};
+};
+
+
+&i2c2 {
+    pinctrl-names = "default";
+    pinctrl-0 = <&i2c2_pins>;
+
+    status = "okay";
+    clock-frequency = <100000>;
+
+    gl_gyro: gl_gyro@68 {
+        compatible = "gl,mpu6050";
+        reg = <0x68>;
+        status = "okay";
+	};
+};
+
+
+/include/ "tps65217.dtsi"
+
+&tps {
+	/*
+	 * Configure pmic to enter OFF-state instead of SLEEP-state ("RTC-only
+	 * mode") at poweroff.  Most BeagleBone versions do not support RTC-only
+	 * mode and risk hardware damage if this mode is entered.
+	 *
+	 * For details, see linux-omap mailing list May 2015 thread
+	 *	[PATCH] ARM: dts: am335x-bone* enable pmic-shutdown-controller
+	 * In particular, messages:
+	 *	http://www.spinics.net/lists/linux-omap/msg118585.html
+	 *	http://www.spinics.net/lists/linux-omap/msg118615.html
+	 *
+	 * You can override this later with
+	 *	&tps {  /delete-property/ ti,pmic-shutdown-controller;  }
+	 * if you want to use RTC-only mode and made sure you are not affected
+	 * by the hardware problems. (Tip: double-check by performing a current
+	 * measurement after shutdown: it should be less than 1 mA.)
+	 */
+	ti,pmic-shutdown-controller;
+
+	interrupt-parent = <&intc>;
+	interrupts = <7>;	/* NNMI */
+
+	regulators {
+		dcdc1_reg: regulator@0 {
+			regulator-name = "vdds_dpr";
+			regulator-always-on;
+		};
+
+		dcdc2_reg: regulator@1 {
+			/* VDD_MPU voltage limits 0.95V - 1.26V with +/-4% tolerance */
+			regulator-name = "vdd_mpu";
+			regulator-min-microvolt = <925000>;
+			regulator-max-microvolt = <1351500>;
+			regulator-boot-on;
+			regulator-always-on;
+		};
+
+		dcdc3_reg: regulator@2 {
+			/* VDD_CORE voltage limits 0.95V - 1.1V with +/-4% tolerance */
+			regulator-name = "vdd_core";
+			regulator-min-microvolt = <925000>;
+			regulator-max-microvolt = <1150000>;
+			regulator-boot-on;
+			regulator-always-on;
+		};
+
+		ldo1_reg: regulator@3 {
+			regulator-name = "vio,vrtc,vdds";
+			regulator-always-on;
+		};
+
+		ldo2_reg: regulator@4 {
+			regulator-name = "vdd_3v3aux";
+			regulator-always-on;
+		};
+
+		ldo3_reg: regulator@5 {
+			regulator-name = "vdd_1v8";
+			regulator-always-on;
+		};
+
+		ldo4_reg: regulator@6 {
+			regulator-name = "vdd_3v3a";
+			regulator-always-on;
+		};
+	};
+};
+
+&cpsw_emac0 {
+	phy_id = <&davinci_mdio>, <0>;
+	phy-mode = "mii";
+};
+
+&mac {
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&cpsw_default>;
+	pinctrl-1 = <&cpsw_sleep>;
+	slaves = <1>;
+	status = "okay";
+};
+
+&davinci_mdio {
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&davinci_mdio_default>;
+	pinctrl-1 = <&davinci_mdio_sleep>;
+	status = "okay";
+};
+
+&mmc1 {
+	status = "okay";
+	bus-width = <0x4>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&mmc1_pins>;
+	cd-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+};
+
+&aes {
+	status = "okay";
+};
+
+&sham {
+	status = "okay";
+};
+
+&wkup_m3_ipc {
+	ti,scale-data-fw = "am335x-bone-scale-data.bin";
+};
+
+&rtc {
+	clocks = <&clk_32768_ck>, <&clkdiv32k_ick>;
+	clock-names = "ext-clk", "int-clk";
+	system-power-controller;
+};
+
+&sgx {
+	status = "okay";
+};
+
+/* the cape manager */
+/ {
+	bone_capemgr {
+		compatible = "ti,bone-capemgr";
+		status = "okay";
+
+		/* nvmem-cells = <&baseboard_data &cape0_data &cape1_data &cape2_data &cape3_data>; */
+		nvmem-cell-names = "baseboard", "slot0", "slot1", "slot2", "slot3";
+		#slots = <4>;
+
+		/* map board revisions to compatible definitions */
+		baseboardmaps {
+			baseboard_beaglebone: board@0 {
+				board-name = "A335BONE";
+				compatible-name = "ti,beaglebone";
+			};
+
+			baseboard_beaglebone_black: board@1 {
+				board-name = "A335BNLT";
+				compatible-name = "ti,beaglebone-black";
+			};
+		};
+	};
+};

--- a/sandbox/ssd1306/build_on_x86.sh
+++ b/sandbox/ssd1306/build_on_x86.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+#export CROSS_COMPILE=${HOME}/BBB/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
+
+MODNAME="ssd1306.ko"
+
+# parse commandline options
+while [ ! -z "$1"  ] ; do
+        case $1 in
+           -h|--help)
+                echo "TODO: help"
+                ;;
+            --clean)
+                echo "Clean module sources"
+                make ARCH=arm clean
+                ;;
+            --module)
+                echo "Build module"
+                make ARCH=arm
+                ;;
+            --deploy)
+                echo "Deploy kernel module"
+                #scp $MODNAME debian@192.168.7.2:/home/debian/
+                #scp $MODNAME bbb:~/
+                #scp $BUILD_KERNEL/arch/arm/boot/dts/am335x-boneblack.dtb bbb:~/
+                #cp $BUILD_KERNEL/arch/arm/boot/dts/am335x-bone-common.dtsi  ./
+                ;;
+            --kconfig)
+                echo "configure kernel"
+                make ARCH=arm config
+                ;;
+            
+            --dtb)
+                echo "configure kernel"
+                cp ./am335x-bone-common.dtsi $BBB_KERNEL/arch/arm/boot/dts/
+                make ARCH=arm dtb
+                ;;
+        esac
+        shift
+done
+
+echo "Done!"

--- a/sandbox/ssd1306/ssd1306.c
+++ b/sandbox/ssd1306/ssd1306.c
@@ -1,0 +1,475 @@
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/input.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/err.h>
+
+
+#include <linux/fb.h>
+#include <linux/uaccess.h>
+
+#define DEVICE_NAME	"lcd_ssd1306"
+#define CLASS_NAME	"oled_display" 
+#define BUS_NAME	"i2c_1"
+
+#define LCD_WIDTH		128
+#define LCD_HEIGHT		64	
+
+#define WRITECOMMAND	0x00 // 
+#define WRITEDATA		0x40 // 
+
+
+
+#define SSD1306_SEND_COMMAND(c, d) i2c_smbus_write_byte_data((c), 0x00, (d))
+
+#define SET_LOW_COLUMN			0x00
+#define SET_HIGH_COLUMN			0x10
+#define COLUMN_ADDR				0x21
+#define PAGE_ADDR				0x22
+#define SET_START_PAGE			0xB0
+#define CHARGE_PUMP				0x8D
+#define DISPLAY_OFF				0xAE
+#define DISPLAY_ON				0xAF
+
+#define MEMORY_MODE				0x20
+#define SET_CONTRAST			0x81
+#define SET_NORMAL_DISPLAY		0xA6
+#define SET_INVERT_DISPLAY		0xA7
+#define COM_SCAN_INC			0xC0
+#define COM_SCAN_DEC			0xC8
+#define SET_DISPLAY_OFFSET		0xD3
+#define SET_DISPLAY_CLOCK_DIV	0xD5
+#define SET_PRECHARGE			0xD9
+#define SET_COM_PINS			0xDA
+#define SET_VCOM_DETECT			0xDB
+
+/* Memory modes */
+enum {
+	SSD1306_MEM_MODE_HORIZONAL = 0,
+	SSD1306_MEM_MODE_VERTICAL,
+	SSD1306_MEM_MODE_PAGE,
+	SSD1306_MEM_MODE_INVALID
+};
+
+static struct device *dev;
+
+
+
+
+struct ssd1306_data {
+    struct i2c_client *client;
+	struct fb_info *info;
+	struct work_struct display_update_ws;
+	u32 height;
+	u32 width;
+
+	int value;
+};
+
+
+static struct fb_fix_screeninfo ssd1307fb_fix = {
+	.id     	= "Solomon SSD1307",
+	.type       = FB_TYPE_PACKED_PIXELS,
+	.visual     = FB_VISUAL_MONO10,
+	.xpanstep   = 0,
+	.ypanstep   = 0,
+	.ywrapstep  = 0,
+	.accel      = FB_ACCEL_NONE,
+};
+
+
+static struct fb_var_screeninfo ssd1307fb_var = {
+	.bits_per_pixel = 1,
+};
+
+
+typedef struct ssd1306_data_array
+{
+	u8      type;
+    u8      data[LCD_WIDTH * LCD_HEIGHT / 8];
+
+} ssd1306_data_array;
+
+ssd1306_data_array dataArray;
+
+/* SSD1306 data buffer */
+u8 *ssd1306_Buffer = &dataArray.data[0];
+static u8 *lcd_vmem;
+
+
+int ssd1306_UpdateScreen(struct ssd1306_data *drv_data);
+int ssd1306_ON(struct ssd1306_data *drv_data);
+int ssd1306_OFF(struct ssd1306_data *drv_data);
+
+/* Init sequence taken from the Adafruit SSD1306 Arduino library */
+static void ssd1306_init_lcd(struct i2c_client *drv_client) {
+
+    dev_info(dev, "ssd1306: Device init \n");
+    /* Init LCD */    
+	SSD1306_SEND_COMMAND(drv_client, DISPLAY_OFF);
+
+	SSD1306_SEND_COMMAND(drv_client, MEMORY_MODE);
+	SSD1306_SEND_COMMAND(drv_client, SSD1306_MEM_MODE_HORIZONAL);
+	/* Set column start / end */
+	SSD1306_SEND_COMMAND(drv_client, COLUMN_ADDR);
+	SSD1306_SEND_COMMAND(drv_client, 0);
+	SSD1306_SEND_COMMAND(drv_client, (LCD_WIDTH - 1));
+
+	/* Set page start / end */
+	SSD1306_SEND_COMMAND(drv_client, PAGE_ADDR);
+	SSD1306_SEND_COMMAND(drv_client, 0);
+	SSD1306_SEND_COMMAND(drv_client, (LCD_HEIGHT / 8 - 1));
+
+	SSD1306_SEND_COMMAND(drv_client, COM_SCAN_DEC);
+
+	SSD1306_SEND_COMMAND(drv_client, SET_CONTRAST);
+	SSD1306_SEND_COMMAND(drv_client, 0xFF); /* Max contrast */
+
+	SSD1306_SEND_COMMAND(drv_client, 0xA1); /* set segment re-map 0 to 127 */
+	SSD1306_SEND_COMMAND(drv_client, SET_NORMAL_DISPLAY);
+	SSD1306_SEND_COMMAND(drv_client, 0xA8); /* set multiplex ratio(1 to 64) */
+	SSD1306_SEND_COMMAND(drv_client, (LCD_HEIGHT - 1));
+	SSD1306_SEND_COMMAND(drv_client, 0xA4); /* 0xA4 => follows RAM content */
+	SSD1306_SEND_COMMAND(drv_client, SET_DISPLAY_OFFSET);
+	SSD1306_SEND_COMMAND(drv_client, 0x00); /* no offset */
+
+	SSD1306_SEND_COMMAND(drv_client, SET_DISPLAY_CLOCK_DIV);
+	SSD1306_SEND_COMMAND(drv_client, 0x80); /* set divide ratio */
+
+	SSD1306_SEND_COMMAND(drv_client, SET_PRECHARGE);
+	SSD1306_SEND_COMMAND(drv_client, 0x22);
+
+	SSD1306_SEND_COMMAND(drv_client, SET_COM_PINS);
+	SSD1306_SEND_COMMAND(drv_client, 0x12);
+
+	SSD1306_SEND_COMMAND(drv_client, SET_VCOM_DETECT);
+	SSD1306_SEND_COMMAND(drv_client, 0x20); /* 0x20, 0.77x Vcc */
+    
+
+	SSD1306_SEND_COMMAND(drv_client, 0x8D);
+	SSD1306_SEND_COMMAND(drv_client, 0x14);
+	SSD1306_SEND_COMMAND(drv_client, 0xAF);
+}
+
+
+
+
+int ssd1306_UpdateScreen(struct ssd1306_data *drv_data) {
+
+    struct i2c_client *drv_client;
+	int ret;
+
+    drv_client = drv_data->client;
+    
+	pr_info("%s", __FUNCTION__);
+    dataArray.type = 0x40;
+	ret = i2c_master_send(drv_client, (u8 *) &dataArray, sizeof(ssd1306_data_array));
+	if (unlikely(ret < 0))
+	{
+		printk(KERN_ERR "i2c_master_send() has returned ERROR %d\n", ret);
+		return ret;
+	}    
+
+    return 0;
+}
+
+
+int ssd1306_ON(struct ssd1306_data *drv_data) {
+	struct i2c_client *drv_client;
+
+	drv_client = drv_data->client;
+
+	pr_info("%s", __FUNCTION__);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0x8D);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0x14);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0xAF);
+	return 0;
+}
+
+
+int ssd1306_OFF(struct ssd1306_data *drv_data) {
+	struct i2c_client *drv_client;
+
+	drv_client = drv_data->client;
+
+	pr_info("%s", __FUNCTION__);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0x8D);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0x10);
+	i2c_smbus_write_byte_data(drv_client, 0x00, 0xAE);
+	return 0;
+}
+
+
+
+
+static void ssd1307fb_update_display(struct ssd1306_data *lcd)
+{
+	u8 *vmem = lcd->info->screen_base;
+	int i, j, k;
+
+	pr_info("%s", __FUNCTION__);
+
+	for (i = 0; i < (lcd->height / 8); i++) {
+		for (j = 0; j < lcd->width; j++) {
+			u32 array_idx = i * lcd->width + j;
+			ssd1306_Buffer[array_idx] = 0;
+			for (k = 0; k < 8; k++) {
+				u32 page_length = lcd->width * i;
+				u32 index = page_length + (lcd->width * k + j) / 8;
+				u8 byte = *(vmem + index);
+				u8 bit = byte & (1 << (j % 8));
+				bit = bit >> (j % 8);
+				ssd1306_Buffer[array_idx] |= bit << k;
+			}
+		}
+	}
+
+
+	ssd1306_UpdateScreen(lcd);
+}
+
+
+static void update_display_work(struct work_struct *work)
+{
+	struct ssd1306_data *lcd =
+		container_of(work, struct ssd1306_data, display_update_ws);
+	ssd1307fb_update_display(lcd);
+	//ssd1306_UpdateScreen(lcd);
+}
+
+
+
+static ssize_t ssd1307fb_write(struct fb_info *info, const char __user *buf,
+		size_t count, loff_t *ppos)
+{
+    struct ssd1306_data *lcd = info->par;
+	unsigned long total_size;
+	unsigned long p = *ppos;
+	u8 __iomem *dst;
+
+	pr_info("%s", __FUNCTION__);
+	total_size = info->fix.smem_len;
+
+	if (p > total_size) {
+		pr_err("%s p > total_size", __FUNCTION__);
+		return -EINVAL;
+	}
+
+	if (count + p > total_size)
+		count = total_size - p;
+
+	if (!count) {
+		pr_err("%s !count", __FUNCTION__);
+		return -EINVAL;
+	}
+
+	dst = (void __force *) (info->screen_base + p);
+
+	if (copy_from_user(dst, buf, count)) {
+		pr_err("%s copy_from_user", __FUNCTION__);
+		//return -EFAULT;
+	}
+
+	schedule_work(&lcd->display_update_ws);
+
+	*ppos += count;
+
+	return count;
+}
+
+static int ssd1307fb_blank(int blank_mode, struct fb_info *info)
+{
+    struct ssd1306_data *lcd = info->par;
+
+	pr_info("%s", __FUNCTION__);
+    if (blank_mode != FB_BLANK_UNBLANK)
+    	return ssd1306_OFF(lcd);
+    else
+    	return ssd1306_ON(lcd);
+}
+
+static void ssd1307fb_fillrect(struct fb_info *info, const struct fb_fillrect *rect)
+{
+    struct ssd1306_data *lcd = info->par;
+	sys_fillrect(info, rect);
+	dev_info(dev, "ssd1307fb_fillrect\n");
+	schedule_work(&lcd->display_update_ws);
+}
+
+static void ssd1307fb_copyarea(struct fb_info *info, const struct fb_copyarea *area)
+{
+    struct ssd1306_data *lcd = info->par;
+	sys_copyarea(info, area);
+	dev_info(dev, "ssd1307fb_copyarea\n");
+	schedule_work(&lcd->display_update_ws);
+}
+
+static void ssd1307fb_imageblit(struct fb_info *info, const struct fb_image *image)
+{
+    struct ssd1306_data *lcd = info->par;
+	sys_imageblit(info, image);
+	dev_info(dev, "ssd1307fb_imageblit\n");
+	schedule_work(&lcd->display_update_ws);
+}
+
+static struct fb_ops ssd1307fb_ops = {
+	.owner          = THIS_MODULE,
+	.fb_read        = fb_sys_read,
+	.fb_write       = ssd1307fb_write,
+	.fb_blank       = ssd1307fb_blank,
+	.fb_fillrect    = ssd1307fb_fillrect,
+	.fb_copyarea    = ssd1307fb_copyarea,
+	.fb_imageblit   = ssd1307fb_imageblit,
+};
+
+
+
+static int ssd1306_probe(struct i2c_client *drv_client,
+			const struct i2c_device_id *id)
+{
+	struct i2c_adapter *adapter;
+	struct fb_info *info;
+	struct ssd1306_data *lcd;
+	u32 vmem_size;
+	u8 *vmem;
+	int ret;
+
+	dev = &drv_client->dev;
+
+	dev_info(dev, "init I2C driver\n");
+
+
+	info = framebuffer_alloc(sizeof(struct ssd1306_data), &drv_client->dev);
+
+	if (!info)
+		return -ENOMEM;
+
+
+	lcd = info->par;
+	lcd->info = info;
+	lcd->client = drv_client;
+
+	i2c_set_clientdata(drv_client, lcd);
+
+	adapter = drv_client->adapter;
+
+	if (!adapter)
+	{
+		dev_err(dev, "adapter indentification error\n");
+		return -ENODEV;
+	}
+
+	dev_info(dev, "I2C client address %d \n", drv_client->addr);
+
+	if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+			dev_err(dev, "operation not supported\n");
+			return -ENODEV;
+	}
+
+	lcd->info = info;
+
+	lcd->width  = LCD_WIDTH;
+	lcd->height = LCD_HEIGHT;
+
+	vmem_size = lcd->width * lcd->height / 8;
+	
+    lcd_vmem = devm_kzalloc(&drv_client->dev, vmem_size, GFP_KERNEL);
+	
+    if (!lcd_vmem) {
+		dev_err(dev, "Couldn't allocate graphical memory.\n");
+		return -ENOMEM;        
+	}
+	
+	vmem = lcd_vmem;//&ssd1306_Buffer[0];
+
+
+	info->fbops     = &ssd1307fb_ops;
+	info->fix       = ssd1307fb_fix;
+	info->fix.line_length = lcd->width / 8;
+
+	info->var = ssd1307fb_var;
+	info->var.xres = lcd->width;
+	info->var.xres_virtual = lcd->width;
+	info->var.yres = lcd->height;
+	info->var.yres_virtual = lcd->height;
+
+	info->var.red.length = 1;
+	info->var.red.offset = 0;
+	info->var.green.length = 1;
+	info->var.green.offset = 0;
+	info->var.blue.length = 1;
+	info->var.blue.offset = 0;
+
+	info->screen_base = (u8 __force __iomem *)vmem;
+	info->fix.smem_start = __pa(vmem);
+	info->fix.smem_len = vmem_size;
+
+
+	i2c_set_clientdata(drv_client, info);
+
+	ssd1306_init_lcd(drv_client);
+	INIT_WORK(&lcd->display_update_ws, update_display_work);
+
+
+	ret = register_framebuffer(info);
+	if (ret) {
+		dev_err(dev, "Couldn't register the framebuffer\n");
+		return ret;
+		//goto panel_init_error;
+	}    
+
+	dev_info(dev, "ssd1306 driver successfully loaded\n");
+	dev_info(dev, "DAndy fb%d: %s device registered, using %d bytes of video memory\n", info->node, info->fix.id, vmem_size);
+
+	return 0;
+}
+
+
+
+static int ssd1306_remove(struct i2c_client *drv_client)
+{
+	struct fb_info *info = i2c_get_clientdata(drv_client);
+    struct ssd1306_data *lcd = info->par;
+
+	cancel_work_sync(&lcd->display_update_ws);
+
+	unregister_framebuffer(info);
+
+	dev_info(dev, "Goodbye, world!\n");
+	return 0;
+}
+
+
+
+static const struct of_device_id ssd1306_match[] = {
+	{ .compatible = "DAndy,lcd_ssd1306", },
+	{ },
+};
+MODULE_DEVICE_TABLE(of, ssd1306_match);
+
+static const struct i2c_device_id ssd1306_id[] = {
+	{ "lcd_ssd1306", 0 },
+	{ }
+};
+MODULE_DEVICE_TABLE(i2c, ssd1306_id);
+
+
+static struct i2c_driver ssd1306_driver = {
+	.driver = {
+		.name	= DEVICE_NAME,
+		.of_match_table = ssd1306_match,
+	},
+	.probe		= ssd1306_probe,
+	.remove 	= ssd1306_remove,
+	.id_table	= ssd1306_id,
+};
+module_i2c_driver(ssd1306_driver);
+
+MODULE_AUTHOR("Devyatov Andrey <andrii.deviatov@globallogic.com>");
+MODULE_DESCRIPTION("ssd1306 I2C");
+MODULE_LICENSE("GPL");

--- a/sandbox/userapp_analog_clock/Makefile
+++ b/sandbox/userapp_analog_clock/Makefile
@@ -1,0 +1,10 @@
+
+
+
+
+all:
+	$(CROSS_COMPILE)gcc -Wall -o analog_clock analog_clock.c
+
+clean:
+	rm fb_user
+

--- a/sandbox/userapp_analog_clock/analog_clock.c
+++ b/sandbox/userapp_analog_clock/analog_clock.c
@@ -1,0 +1,398 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <linux/fb.h>
+#include <linux/kd.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <string.h>
+
+#include <math.h>
+#include <unistd.h>
+
+typedef unsigned char 	u8;
+typedef unsigned short 	u16;
+
+#define SSD1306_WIDTH	128
+#define SSD1306_HEIGHT	64
+
+
+
+typedef struct{
+	u16 	X;
+	u16 	Y;
+}_Point;
+
+typedef enum {
+		SSD1306_COLOR_BLACK = 0x00,   /*!< Black color, no pixel */
+		SSD1306_COLOR_WHITE = 0x01    /*!< Pixel is set. Color depends on LCD */
+} ssd1306_COLOR_t;
+
+
+typedef struct {
+	struct fb_var_screeninfo vinfo;
+	struct fb_fix_screeninfo finfo;
+	int width;
+	int height;
+	long int screensize;
+	char *fbp;
+
+}lcd_type;
+
+static lcd_type lcd;
+
+
+static u8 ssd1306_Buffer[SSD1306_WIDTH * SSD1306_HEIGHT / 8];
+
+
+
+static int ssd1306_DrawPixel(u16 x, u16 y, ssd1306_COLOR_t color) {
+
+	if ( x > SSD1306_WIDTH || y > SSD1306_HEIGHT ) {
+		return -1;
+	}
+
+	/* Set color */
+	if (color == SSD1306_COLOR_WHITE) {
+		ssd1306_Buffer[x/8 + (y * (SSD1306_WIDTH / 8))] |= (1 << (x % 8));
+	}
+	else {
+		ssd1306_Buffer[x/8 + (y * (SSD1306_WIDTH / 8))] &= ~(1 << (x % 8));
+	}
+
+	return 0;
+}
+
+
+
+static void Graphic_setPoint(const u16 X, const u16 Y, ssd1306_COLOR_t color)
+{
+	ssd1306_DrawPixel(X, Y, color);
+}
+
+
+
+static void Graphic_drawLine(_Point p1, _Point p2, ssd1306_COLOR_t color){
+	int dx, dy, inx, iny, e;
+	u16 x1 = p1.X, x2 = p2.X;
+	u16 y1 = p1.Y, y2 = p2.Y;
+
+	dx = x2 - x1;
+	dy = y2 - y1;
+	inx = dx > 0 ? 1 : -1;
+	iny = dy > 0 ? 1 : -1;
+
+	dx = (dx > 0) ? dx : -dx;
+	dy = (dy > 0) ? dy : -dy;
+
+
+	if(dx >= dy) {
+		dy <<= 1;
+		e = dy - dx;
+		dx <<= 1;
+		while (x1 != x2){
+			Graphic_setPoint(x1, y1, color);
+			if(e >= 0){
+				y1 += iny;
+				e-= dx;
+			}
+			e += dy;
+			x1 += inx;
+		}
+	}
+	else{
+		dx <<= 1;
+		e = dx - dy;
+		dy <<= 1;
+		while (y1 != y2){
+			Graphic_setPoint(x1, y1, color);
+			if(e >= 0){
+				x1 += inx;
+				e -= dy;
+			}
+			e += dx;
+			y1 += iny;
+		}	}
+	Graphic_setPoint(x1, y1, color);
+}
+// ---------------------------------------------------------------------------
+
+
+static void Graphic_drawLine_(u16 x1, u16 y1, u16 x2, u16 y2,
+	ssd1306_COLOR_t color)
+{
+	_Point p1 = {0}, p2 = {0};
+	p1.X = x1;
+	p1.Y = y1;
+	p2.X = x2;
+	p2.Y = y2;
+
+	Graphic_drawLine(p1, p2, color);
+}
+// ---------------------------------------------------------------------------
+
+
+
+void Graphic_drawCircle(_Point center, u16 r){
+	int  draw_x0, draw_y0;			//draw points
+	int  draw_x1, draw_y1;
+	int  draw_x2, draw_y5;
+	int  draw_x3, draw_y3;
+	int  draw_x4, draw_y4;
+	int  draw_x6, draw_y6;
+	int  draw_x7, draw_y7;
+	int  draw_x5, draw_y2;
+	int  xx, yy;					// circle control variable
+	int  di;						// decide variable
+	
+	if( 0 == r)
+		return;
+
+	// calculate 8 special point(0��45��90��135��180��225��270degree) display them 
+	draw_x0 = draw_x1 = center.X;
+	draw_y0 = draw_y1 = center.Y + r;
+	if(draw_y0<63)
+		Graphic_setPoint(draw_x0, draw_y0, SSD1306_COLOR_WHITE); // 90degree
+	draw_x2 = draw_x3 = center.X;
+	draw_y2 = draw_y3 = center.Y - r;
+	if(draw_y2>=0)
+		Graphic_setPoint(draw_x2,draw_y2, SSD1306_COLOR_WHITE);// 270degree
+	draw_x4 = draw_x6 = center.X + r;
+	draw_y4 = draw_y6 = center.Y;
+	if(draw_x4<127)
+		Graphic_setPoint(draw_x4, draw_y4, SSD1306_COLOR_WHITE);// 0degree
+	draw_x5 = draw_x7 = center.X - r;
+	draw_y5 = draw_y7 = center.Y;
+	if(draw_x5>=0)
+		Graphic_setPoint(draw_x5, draw_y5, SSD1306_COLOR_WHITE); // 180degree
+	if(1==r)   // if the radius is 1, finished.
+		return;
+	//using Bresenham 
+	di = 3 - 2*r;
+	xx = 0;
+	yy = r;
+	while(xx<yy){
+		if(di<0){
+			di += 4*xx + 6;
+		}else{
+			di += 4*(xx - yy) + 10;
+			yy--;
+			draw_y0--;
+			draw_y1--;
+			draw_y2++;
+			draw_y3++;
+			draw_x4--;
+			draw_x5++;
+			draw_x6--;
+			draw_x7++;
+		}
+		xx++;
+		draw_x0++;
+		draw_x1--;
+		draw_x2++;
+		draw_x3--;
+		draw_y4++;
+		draw_y5++;
+		draw_y6--;
+		draw_y7--;
+		//judge current point in the avaible range
+		if( (draw_x0<=127)&&(draw_y0>=0) ){
+			Graphic_setPoint(draw_x0, draw_y0, SSD1306_COLOR_WHITE);
+		}	
+		if( (draw_x1>=0)&&(draw_y1>=0) ){
+			Graphic_setPoint(draw_x1, draw_y1, SSD1306_COLOR_WHITE);
+		}
+		if( (draw_x2<=127)&&(draw_y2<=63) ){
+			Graphic_setPoint(draw_x2, draw_y2, SSD1306_COLOR_WHITE);
+		}
+		if( (draw_x3>=0)&&(draw_y3<=63) ){ 
+			Graphic_setPoint(draw_x3, draw_y3, SSD1306_COLOR_WHITE);
+		}
+		if( (draw_x4<=127)&&(draw_y4>=0) ){
+			Graphic_setPoint(draw_x4, draw_y4, SSD1306_COLOR_WHITE);
+		}
+		if( (draw_x5>=0)&&(draw_y5>=0) ){
+			Graphic_setPoint(draw_x5, draw_y5, SSD1306_COLOR_WHITE);
+		}
+		if( (draw_x6<=127)&&(draw_y6<=63) ){
+			Graphic_setPoint(draw_x6, draw_y6, SSD1306_COLOR_WHITE);
+		}
+		if( (draw_x7>=0)&&(draw_y7<=63) ){ 
+			Graphic_setPoint(draw_x7, draw_y7, SSD1306_COLOR_WHITE);
+		}
+	}
+}
+
+
+static void Graphic_ClearScreen(void){
+	memset(ssd1306_Buffer, 0, sizeof(ssd1306_Buffer));
+}
+
+
+int fb;
+
+static void Graphic_UpdateScreen(void){
+
+	int i = 0;
+
+	for (i=0; i < lcd.screensize; i++) {
+
+		*(lcd.fbp+i) = ssd1306_Buffer[i];
+	}
+}
+
+
+
+struct fb_var_screeninfo fb_var;
+struct fb_var_screeninfo fb_screen;
+struct fb_fix_screeninfo fb_fix;
+unsigned char *fb_mem = NULL;
+unsigned char *fb_screenMem = NULL;
+
+
+
+#ifndef PAGE_SHIFT
+	#define PAGE_SHIFT 12
+#endif
+#ifndef PAGE_SIZE
+	#define PAGE_SIZE (1UL << PAGE_SHIFT)
+#endif
+#ifndef PAGE_MASK
+	#define PAGE_MASK (~(PAGE_SIZE - 1))
+#endif
+
+int fb_init(char *device) {
+
+	int fb_mem_offset;
+
+	// get current settings (which we have to restore)
+	if (-1 == (fb = open(device, O_RDWR))) {
+		fprintf(stderr, "Open %s error\n", device);
+		return 0;
+	}
+	if (-1 == ioctl(fb, FBIOGET_VSCREENINFO, &fb_var)) {
+		fprintf(stderr, "Ioctl FBIOGET_VSCREENINFO error.\n");
+		return 0;
+	}
+	if (-1 == ioctl(fb, FBIOGET_FSCREENINFO, &fb_fix)) {
+		fprintf(stderr, "Ioctl FBIOGET_FSCREENINFO error.\n");
+		return 0;
+	}
+	if (fb_fix.type != FB_TYPE_PACKED_PIXELS) {
+		fprintf(stderr, "Can handle only packed pixel frame buffers.\n");
+		goto err;
+	}
+
+	fb_mem_offset = (unsigned long)(fb_fix.smem_start) & (~PAGE_MASK);
+	fb_mem = mmap(NULL, fb_fix.smem_len + fb_mem_offset, PROT_READ | PROT_WRITE, MAP_SHARED, fb, 0);
+	if (-1L == (long)fb_mem) {
+		fprintf(stderr, "Mmap error.\n");
+		goto err;
+	}
+	// move viewport to upper left corner
+	if (fb_var.xoffset != 0 || fb_var.yoffset != 0) {
+		fb_var.xoffset = 0;
+		fb_var.yoffset = 0;
+		if (-1 == ioctl(fb, FBIOPAN_DISPLAY, &fb_var)) {
+			fprintf(stderr, "Ioctl FBIOPAN_DISPLAY error.\n");
+			munmap(fb_mem, fb_fix.smem_len);
+			goto err;
+		}
+	}
+ 
+
+	lcd.width 		= fb_var.xres;
+	lcd.height 		= fb_var.yres;
+	lcd.screensize 	= fb_var.xres * fb_var.yres * fb_var.bits_per_pixel / 8;
+	lcd.fbp 		= fb_mem;
+
+	printf("lcd.width %d\n", lcd.width);
+	printf("lcd.height %d\n", lcd.height);
+	printf("lcd.screensize %ld\n", lcd.screensize);
+	printf("lcd.fbp %p\n", lcd.fbp);
+
+	return 1;
+
+err:
+	if (-1 == ioctl(fb, FBIOPUT_VSCREENINFO, &fb_var))
+		fprintf(stderr, "Ioctl FBIOPUT_VSCREENINFO error.\n");
+	if (-1 == ioctl(fb, FBIOGET_FSCREENINFO, &fb_fix))
+		fprintf(stderr, "Ioctl FBIOGET_FSCREENINFO.\n");
+	return 0;
+}
+
+void fb_cleanup(void) {
+
+	if (-1 == ioctl(fb, FBIOPUT_VSCREENINFO, &fb_var))
+		fprintf(stderr, "Ioctl FBIOPUT_VSCREENINFO error.\n");
+	if (-1 == ioctl(fb, FBIOGET_FSCREENINFO, &fb_fix))
+		fprintf(stderr, "Ioctl FBIOGET_FSCREENINFO.\n");
+	munmap(fb_mem, fb_fix.smem_len);
+	close(fb);
+}
+
+
+void draw_hatches(_Point center, int radius)
+{
+	float angle2 = 0.0;
+	for(angle2 = 0.0; angle2 <= 360; ){
+		Graphic_drawLine_(
+			center.X + (radius -4) * cos((M_PI/180.0)*angle2 - M_PI/2),
+			center.Y + (radius -4) * sin((M_PI/180.0)*angle2 - M_PI/2),
+
+			center.X + radius * cos((M_PI/180.0)*angle2 - M_PI/2),
+			center.Y + radius * sin((M_PI/180.0)*angle2 - M_PI/2),
+			SSD1306_COLOR_WHITE);
+			
+			angle2 += 90.0;
+	}
+	printf("%s\n", __func__);
+}
+
+int main(int argc, char **argv)
+{	
+	int x = 0, y = 0, i = 0;
+	u16 x2_prev = 0, y2_prev = 0;
+	float angle_prev = 0.0;
+	long int location = 0;
+	
+	_Point center;
+	int radius = 0;
+	float angle = 0.0;
+
+	if (!fb_init("/dev/fb0"))
+		exit(1);
+
+	Graphic_ClearScreen();
+
+	center.X 	= lcd.width / 2;
+	center.Y 	= lcd.height / 2;
+	radius 		= 31;
+	Graphic_drawCircle(center, radius);
+
+	//for(angle = 0.0; angle <= 360; ){
+	for(angle = 0.0; ; ){
+		Graphic_drawLine_(center.X, center.Y, 
+				x2_prev, y2_prev, SSD1306_COLOR_BLACK);
+
+		if (fmod(angle_prev, 90.0) == 0)
+			draw_hatches(center, radius);
+
+		x2_prev = center.X + (radius -4) * cos((M_PI/180.0)*angle - M_PI/2);
+		y2_prev = center.Y + (radius -4) * sin((M_PI/180.0)*angle - M_PI/2);
+		angle_prev = angle;
+
+		Graphic_drawLine_(center.X, center.Y, 
+				x2_prev, y2_prev, SSD1306_COLOR_WHITE);
+		angle += 6.0;
+		Graphic_UpdateScreen();
+		sleep(1);
+	}
+
+	Graphic_UpdateScreen();
+		  
+
+	fb_cleanup();
+	return(0);
+}

--- a/sandbox/userapp_analog_clock/build_user_app.sh
+++ b/sandbox/userapp_analog_clock/build_user_app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+#export CROSS_COMPILE=${HOME}/BBB/gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux/bin/arm-linux-gnueabihf-
+
+echo ${CROSS_COMPILE}
+
+
+${CROSS_COMPILE}gcc analog_clock.c -o analog_clock -lm
+
+
+echo "Done!"


### PR DESCRIPTION
Added base implemantaion of lcd-driver.
Added slightly improved user-aplication: avoided redundant redrawing.
Added sample of uEnv.txt that allows to use i2c1 for ssd1306.
Rude disabling of hdmi in device tree: for some reason was created
fb0 and no interruption were received for fb1 (ssd1306) and cape_disable doesn't work for that purpose.